### PR TITLE
Translation files lack language declaration

### DIFF
--- a/etc/themes/classic/Theme-Classic-fr_FR.ts
+++ b/etc/themes/classic/Theme-Classic-fr_FR.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="fr_FR">
 <context>
     <name>home</name>
     <message>

--- a/etc/themes/classic/Theme-Classic-it_IT.ts
+++ b/etc/themes/classic/Theme-Classic-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/crisp/Theme-Crisp-fr_FR.ts
+++ b/etc/themes/crisp/Theme-Crisp-fr_FR.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="fr_FR">
 <context>
     <name>home</name>
     <message>

--- a/etc/themes/crisp/Theme-Crisp-it_IT.ts
+++ b/etc/themes/crisp/Theme-Crisp-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-cs_CZ.ts
+++ b/etc/themes/faenqo/Theme-faenqo-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-da_DK.ts
+++ b/etc/themes/faenqo/Theme-faenqo-da_DK.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-de_DE.ts
+++ b/etc/themes/faenqo/Theme-faenqo-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-en_US.ts
+++ b/etc/themes/faenqo/Theme-faenqo-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-es_ES.ts
+++ b/etc/themes/faenqo/Theme-faenqo-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-fr_FR.ts
+++ b/etc/themes/faenqo/Theme-faenqo-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-it_IT.ts
+++ b/etc/themes/faenqo/Theme-faenqo-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-pl_PL.ts
+++ b/etc/themes/faenqo/Theme-faenqo-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/faenqo/Theme-faenqo-ru_RU.ts
+++ b/etc/themes/faenqo/Theme-faenqo-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finxi/Theme-Finxi-cs_CZ.ts
+++ b/etc/themes/finxi/Theme-Finxi-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finxi/Theme-Finxi-da_DK.ts
+++ b/etc/themes/finxi/Theme-Finxi-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finxi/Theme-Finxi-de_DE.ts
+++ b/etc/themes/finxi/Theme-Finxi-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finxi/Theme-Finxi-en_US.ts
+++ b/etc/themes/finxi/Theme-Finxi-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finxi/Theme-Finxi-es_ES.ts
+++ b/etc/themes/finxi/Theme-Finxi-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finxi/Theme-Finxi-fr_FR.ts
+++ b/etc/themes/finxi/Theme-Finxi-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finxi/Theme-Finxi-it_IT.ts
+++ b/etc/themes/finxi/Theme-Finxi-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finxi/Theme-Finxi-pl_PL.ts
+++ b/etc/themes/finxi/Theme-Finxi-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finximod/Theme-FinxiMod-cs_CZ.ts
+++ b/etc/themes/finximod/Theme-FinxiMod-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finximod/Theme-FinxiMod-da_DK.ts
+++ b/etc/themes/finximod/Theme-FinxiMod-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finximod/Theme-FinxiMod-de_DE.ts
+++ b/etc/themes/finximod/Theme-FinxiMod-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finximod/Theme-FinxiMod-en_US.ts
+++ b/etc/themes/finximod/Theme-FinxiMod-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finximod/Theme-FinxiMod-es_ES.ts
+++ b/etc/themes/finximod/Theme-FinxiMod-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finximod/Theme-FinxiMod-it_IT.ts
+++ b/etc/themes/finximod/Theme-FinxiMod-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finximod/Theme-FinxiMod-pl_PL.ts
+++ b/etc/themes/finximod/Theme-FinxiMod-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/finximod/Theme-FinxiMod-ru_RU.ts
+++ b/etc/themes/finximod/Theme-FinxiMod-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/qtopia/Theme-Qtopia-fr_FR.ts
+++ b/etc/themes/qtopia/Theme-Qtopia-fr_FR.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="fr_FR">
 <context>
     <name>home</name>
     <message>

--- a/etc/themes/qtopia/Theme-Qtopia-it_IT.ts
+++ b/etc/themes/qtopia/Theme-Qtopia-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>home</name>
     <message numerus="yes">

--- a/etc/themes/smart/Theme-Smart-cs_CZ.ts
+++ b/etc/themes/smart/Theme-Smart-cs_CZ.ts
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 </TS>

--- a/etc/themes/smart/Theme-Smart-fr_FR.ts
+++ b/etc/themes/smart/Theme-Smart-fr_FR.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 </TS>

--- a/etc/themes/smart/Theme-Smart-it_IT.ts
+++ b/etc/themes/smart/Theme-Smart-it_IT.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 </TS>

--- a/etc/themes/smart/Theme-Smart-ru_RU.ts
+++ b/etc/themes/smart/Theme-Smart-ru_RU.ts
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="ru_RU">
 </TS>

--- a/examples/scribble/scribble-en_US.ts
+++ b/examples/scribble/scribble-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>MainWindow</name>
     <message>

--- a/examples/webviewer/webviewer-cs_CZ.ts
+++ b/examples/webviewer/webviewer-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>CookieExceptionsModel</name>
     <message>

--- a/examples/webviewer/webviewer-de_DE.ts
+++ b/examples/webviewer/webviewer-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>CookieExceptionsModel</name>
     <message>

--- a/examples/webviewer/webviewer-en_US.ts
+++ b/examples/webviewer/webviewer-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/examples/webviewer/webviewer-es_ES.ts
+++ b/examples/webviewer/webviewer-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>CookieExceptionsModel</name>
     <message>

--- a/examples/webviewer/webviewer-it_IT.ts
+++ b/examples/webviewer/webviewer-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>CookieExceptionsModel</name>
     <message>

--- a/examples/webviewer/webviewer-nct-cs_CZ.ts
+++ b/examples/webviewer/webviewer-nct-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>WebViewer</name>
     <message>

--- a/examples/webviewer/webviewer-nct-de_DE.ts
+++ b/examples/webviewer/webviewer-nct-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>WebViewer</name>
     <message>

--- a/examples/webviewer/webviewer-nct-en_US.ts
+++ b/examples/webviewer/webviewer-nct-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/examples/webviewer/webviewer-nct-es_ES.ts
+++ b/examples/webviewer/webviewer-nct-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>WebViewer</name>
     <message>

--- a/examples/webviewer/webviewer-nct-it_IT.ts
+++ b/examples/webviewer/webviewer-nct-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>WebViewer</name>
     <message>

--- a/examples/webviewer/webviewer-nct-ru_RU.ts
+++ b/examples/webviewer/webviewer-nct-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>WebViewer</name>
     <message>

--- a/examples/webviewer/webviewer-ru_RU.ts
+++ b/examples/webviewer/webviewer-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>CookieExceptionsModel</name>
     <message>

--- a/examples/whereabouts/mappingdemo/mappingdemo-cs_CZ.ts
+++ b/examples/whereabouts/mappingdemo/mappingdemo-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>MappingDemo</name>
     <message>

--- a/examples/whereabouts/mappingdemo/mappingdemo-de_DE.ts
+++ b/examples/whereabouts/mappingdemo/mappingdemo-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>MappingDemo</name>
     <message>

--- a/examples/whereabouts/mappingdemo/mappingdemo-en_US.ts
+++ b/examples/whereabouts/mappingdemo/mappingdemo-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/examples/whereabouts/mappingdemo/mappingdemo-es_ES.ts
+++ b/examples/whereabouts/mappingdemo/mappingdemo-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>MappingDemo</name>
     <message>

--- a/examples/whereabouts/mappingdemo/mappingdemo-fr_FR.ts
+++ b/examples/whereabouts/mappingdemo/mappingdemo-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>MappingDemo</name>
     <message>

--- a/examples/whereabouts/mappingdemo/mappingdemo-it_IT.ts
+++ b/examples/whereabouts/mappingdemo/mappingdemo-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>MappingDemo</name>
     <message>

--- a/examples/whereabouts/mappingdemo/mappingdemo-ru_RU.ts
+++ b/examples/whereabouts/mappingdemo/mappingdemo-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>MappingDemo</name>
     <message>

--- a/i18n/cs_CZ/QtopiaHandwriting.ts
+++ b/i18n/cs_CZ/QtopiaHandwriting.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>FullScreen</name>
     <message>

--- a/i18n/cs_CZ/QtopiaHomeDefaults.ts
+++ b/i18n/cs_CZ/QtopiaHomeDefaults.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>QPE</name>
     <message>

--- a/i18n/cs_CZ/QtopiaRingTones.ts
+++ b/i18n/cs_CZ/QtopiaRingTones.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>Content</name>
     <message>

--- a/i18n/cs_CZ/QtopiaServices.ts
+++ b/i18n/cs_CZ/QtopiaServices.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>Alarm</name>
     <message>

--- a/i18n/de_DE/QtopiaHomeDefaults.ts
+++ b/i18n/de_DE/QtopiaHomeDefaults.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>QPE</name>
     <message>

--- a/i18n/en_US/CalcAreaConv.ts
+++ b/i18n/en_US/CalcAreaConv.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/CalcDistConv.ts
+++ b/i18n/en_US/CalcDistConv.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/CalcVolConv.ts
+++ b/i18n/en_US/CalcVolConv.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/CalcWeightConv.ts
+++ b/i18n/en_US/CalcWeightConv.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/Categories-Qtopia.ts
+++ b/i18n/en_US/Categories-Qtopia.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaApplications.ts
+++ b/i18n/en_US/QtopiaApplications.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaBeaming.ts
+++ b/i18n/en_US/QtopiaBeaming.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaColorSchemes.ts
+++ b/i18n/en_US/QtopiaColorSchemes.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaDefaults.ts
+++ b/i18n/en_US/QtopiaDefaults.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaGames.ts
+++ b/i18n/en_US/QtopiaGames.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaHandwriting.ts
+++ b/i18n/en_US/QtopiaHandwriting.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaHomeDefaults.ts
+++ b/i18n/en_US/QtopiaHomeDefaults.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaI18N.ts
+++ b/i18n/en_US/QtopiaI18N.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaOperatorCountry.ts
+++ b/i18n/en_US/QtopiaOperatorCountry.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaRingTones.ts
+++ b/i18n/en_US/QtopiaRingTones.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaServices.ts
+++ b/i18n/en_US/QtopiaServices.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaSettings.ts
+++ b/i18n/en_US/QtopiaSettings.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/en_US/QtopiaThemes.ts
+++ b/i18n/en_US/QtopiaThemes.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/i18n/es_ES/CalcAreaConv.ts
+++ b/i18n/es_ES/CalcAreaConv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Area</name>
     <message utf8="true">

--- a/i18n/es_ES/CalcDistConv.ts
+++ b/i18n/es_ES/CalcDistConv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Distances</name>
     <message>

--- a/i18n/es_ES/CalcVolConv.ts
+++ b/i18n/es_ES/CalcVolConv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Volume</name>
     <message>

--- a/i18n/es_ES/CalcWeightConv.ts
+++ b/i18n/es_ES/CalcWeightConv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Weights</name>
     <message>

--- a/i18n/es_ES/Categories-Qtopia.ts
+++ b/i18n/es_ES/Categories-Qtopia.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Categories</name>
     <message>

--- a/i18n/es_ES/QtopiaApplications.ts
+++ b/i18n/es_ES/QtopiaApplications.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Archives</name>
     <message>

--- a/i18n/es_ES/QtopiaBeaming.ts
+++ b/i18n/es_ES/QtopiaBeaming.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Quoted ASCII</name>
     <message>

--- a/i18n/es_ES/QtopiaColorSchemes.ts
+++ b/i18n/es_ES/QtopiaColorSchemes.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>ColorScheme</name>
     <message>

--- a/i18n/es_ES/QtopiaDefaults.ts
+++ b/i18n/es_ES/QtopiaDefaults.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Contacts</name>
     <message>

--- a/i18n/es_ES/QtopiaGames.ts
+++ b/i18n/es_ES/QtopiaGames.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Asteroids</name>
     <message>

--- a/i18n/es_ES/QtopiaHandwriting.ts
+++ b/i18n/es_ES/QtopiaHandwriting.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>FullScreen</name>
     <message>

--- a/i18n/es_ES/QtopiaHomeDefaults.ts
+++ b/i18n/es_ES/QtopiaHomeDefaults.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>QPE</name>
     <message>

--- a/i18n/es_ES/QtopiaI18N.ts
+++ b/i18n/es_ES/QtopiaI18N.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Czech</name>
     <message utf8="true">

--- a/i18n/es_ES/QtopiaOperatorCountry.ts
+++ b/i18n/es_ES/QtopiaOperatorCountry.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Countries</name>
     <message>

--- a/i18n/es_ES/QtopiaRingTones.ts
+++ b/i18n/es_ES/QtopiaRingTones.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Content</name>
     <message>

--- a/i18n/es_ES/QtopiaServices.ts
+++ b/i18n/es_ES/QtopiaServices.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Alarm</name>
     <message>

--- a/i18n/es_ES/QtopiaSettings.ts
+++ b/i18n/es_ES/QtopiaSettings.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Appearance</name>
     <message utf8="true">

--- a/i18n/es_ES/QtopiaThemes.ts
+++ b/i18n/es_ES/QtopiaThemes.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Themes</name>
     <message>

--- a/i18n/fr_FR/Categories-Qtopia.ts
+++ b/i18n/fr_FR/Categories-Qtopia.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>Categories</name>
     <message>

--- a/i18n/fr_FR/QtopiaApplications.ts
+++ b/i18n/fr_FR/QtopiaApplications.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>Archives</name>
     <message>

--- a/i18n/fr_FR/QtopiaColorSchemes.ts
+++ b/i18n/fr_FR/QtopiaColorSchemes.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>ColorScheme</name>
     <message>

--- a/i18n/fr_FR/QtopiaDefaults.ts
+++ b/i18n/fr_FR/QtopiaDefaults.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>Contacts</name>
     <message>

--- a/i18n/fr_FR/QtopiaGames.ts
+++ b/i18n/fr_FR/QtopiaGames.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>Asteroids</name>
     <message>

--- a/i18n/fr_FR/QtopiaSettings.ts
+++ b/i18n/fr_FR/QtopiaSettings.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>Appearance</name>
     <message utf8="true">

--- a/i18n/it_IT/CalcAreaConv.ts
+++ b/i18n/it_IT/CalcAreaConv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Area</name>
     <message utf8="true">

--- a/i18n/it_IT/CalcDistConv.ts
+++ b/i18n/it_IT/CalcDistConv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Distances</name>
     <message>

--- a/i18n/it_IT/CalcVolConv.ts
+++ b/i18n/it_IT/CalcVolConv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Volume</name>
     <message>

--- a/i18n/it_IT/CalcWeightConv.ts
+++ b/i18n/it_IT/CalcWeightConv.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Weights</name>
     <message>

--- a/i18n/it_IT/Categories-Qtopia.ts
+++ b/i18n/it_IT/Categories-Qtopia.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Categories</name>
     <message>

--- a/i18n/it_IT/QtopiaApplications.ts
+++ b/i18n/it_IT/QtopiaApplications.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Archives</name>
     <message>

--- a/i18n/it_IT/QtopiaBeaming.ts
+++ b/i18n/it_IT/QtopiaBeaming.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Quoted ASCII</name>
     <message>

--- a/i18n/it_IT/QtopiaColorSchemes.ts
+++ b/i18n/it_IT/QtopiaColorSchemes.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>ColorScheme</name>
     <message>

--- a/i18n/it_IT/QtopiaDefaults.ts
+++ b/i18n/it_IT/QtopiaDefaults.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Contacts</name>
     <message>

--- a/i18n/it_IT/QtopiaGames.ts
+++ b/i18n/it_IT/QtopiaGames.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Asteroids</name>
     <message>

--- a/i18n/it_IT/QtopiaHandwriting.ts
+++ b/i18n/it_IT/QtopiaHandwriting.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>FullScreen</name>
     <message>

--- a/i18n/it_IT/QtopiaHomeDefaults.ts
+++ b/i18n/it_IT/QtopiaHomeDefaults.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QPE</name>
     <message>

--- a/i18n/it_IT/QtopiaI18N.ts
+++ b/i18n/it_IT/QtopiaI18N.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Czech</name>
     <message utf8="true">

--- a/i18n/it_IT/QtopiaOperatorCountry.ts
+++ b/i18n/it_IT/QtopiaOperatorCountry.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Countries</name>
     <message>

--- a/i18n/it_IT/QtopiaRingTones.ts
+++ b/i18n/it_IT/QtopiaRingTones.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Content</name>
     <message>

--- a/i18n/it_IT/QtopiaServices.ts
+++ b/i18n/it_IT/QtopiaServices.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Alarm</name>
     <message>

--- a/i18n/it_IT/QtopiaSettings.ts
+++ b/i18n/it_IT/QtopiaSettings.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Appearance</name>
     <message utf8="true">

--- a/i18n/it_IT/QtopiaThemes.ts
+++ b/i18n/it_IT/QtopiaThemes.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Themes</name>
     <message>

--- a/i18n/ru_RU/QtopiaBeaming.ts
+++ b/i18n/ru_RU/QtopiaBeaming.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>Quoted ASCII</name>
     <message>

--- a/i18n/ru_RU/QtopiaHomeDefaults.ts
+++ b/i18n/ru_RU/QtopiaHomeDefaults.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>QPE</name>
     <message>

--- a/i18n/ru_RU/QtopiaRingTones.ts
+++ b/i18n/ru_RU/QtopiaRingTones.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>Content</name>
     <message>

--- a/i18n/ru_RU/QtopiaThemes.ts
+++ b/i18n/ru_RU/QtopiaThemes.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>Themes</name>
     <message>

--- a/src/3rdparty/applications/neocontrol/neocontrol-en_US.ts
+++ b/src/3rdparty/applications/neocontrol/neocontrol-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/3rdparty/applications/qmplayer/qmplayer-en_US.ts
+++ b/src/3rdparty/applications/qmplayer/qmplayer-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/3rdparty/applications/qterminal/qterminal-en_US.ts
+++ b/src/3rdparty/applications/qterminal/qterminal-en_US.ts
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="en_US">
 </TS>

--- a/src/3rdparty/applications/qx/qx-en_US.ts
+++ b/src/3rdparty/applications/qx/qx-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/3rdparty/applications/qx_helper/qx_helper-en_US.ts
+++ b/src/3rdparty/applications/qx_helper/qx_helper-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/3rdparty/applications/simplefm/simplefm-fr_FR.ts
+++ b/src/3rdparty/applications/simplefm/simplefm-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>QLocalUrlModel</name>
     <message>

--- a/src/3rdparty/games/qnetwalk/translations/qnetwalk_de.ts
+++ b/src/3rdparty/games/qnetwalk/translations/qnetwalk_de.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="de">
 <context>
     <name>MainWindow</name>
     <message>

--- a/src/3rdparty/games/qnetwalk/translations/qnetwalk_es.ts
+++ b/src/3rdparty/games/qnetwalk/translations/qnetwalk_es.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="es">
 <context>
     <name>MainWindow</name>
     <message>

--- a/src/3rdparty/games/qnetwalk/translations/qnetwalk_fr.ts
+++ b/src/3rdparty/games/qnetwalk/translations/qnetwalk_fr.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="fr">
 <context>
     <name>MainWindow</name>
     <message>

--- a/src/3rdparty/games/qnetwalk/translations/qnetwalk_nl.ts
+++ b/src/3rdparty/games/qnetwalk/translations/qnetwalk_nl.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="nl">
 <context>
     <name>MainWindow</name>
     <message>

--- a/src/3rdparty/games/qnetwalk/translations/qnetwalk_pl.ts
+++ b/src/3rdparty/games/qnetwalk/translations/qnetwalk_pl.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="pl">
 <context>
     <name>MainWindow</name>
     <message>

--- a/src/3rdparty/games/qnetwalk/translations/qnetwalk_pt_BR.ts
+++ b/src/3rdparty/games/qnetwalk/translations/qnetwalk_pt_BR.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="pt_BR">
 <context>
     <name>MainWindow</name>
     <message>

--- a/src/3rdparty/games/qnetwalk/translations/qnetwalk_ru.ts
+++ b/src/3rdparty/games/qnetwalk/translations/qnetwalk_ru.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="ru">
 <context>
     <name>MainWindow</name>
     <message>

--- a/src/3rdparty/games/qtmaze/qtmaze-en_US.ts
+++ b/src/3rdparty/games/qtmaze/qtmaze-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/3rdparty/plugins/inputmethods/pkim/libpkim-da_DK.ts
+++ b/src/3rdparty/plugins/inputmethods/pkim/libpkim-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>InputMethods</name>
     <message>

--- a/src/3rdparty/plugins/inputmethods/pkim/libpkim-de_DE.ts
+++ b/src/3rdparty/plugins/inputmethods/pkim/libpkim-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>InputMethods</name>
     <message>

--- a/src/3rdparty/plugins/inputmethods/pkim/libpkim-en_US.ts
+++ b/src/3rdparty/plugins/inputmethods/pkim/libpkim-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/3rdparty/plugins/inputmethods/pkim/libpkim-es_ES.ts
+++ b/src/3rdparty/plugins/inputmethods/pkim/libpkim-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>InputMethods</name>
     <message>

--- a/src/3rdparty/plugins/inputmethods/pkim/libpkim-it_IT.ts
+++ b/src/3rdparty/plugins/inputmethods/pkim/libpkim-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>InputMethods</name>
     <message>

--- a/src/3rdparty/plugins/inputmethods/pkim/libpkim-pl_PL.ts
+++ b/src/3rdparty/plugins/inputmethods/pkim/libpkim-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>InputMethods</name>
     <message>

--- a/src/applications/addressbook/addressbook-da_DK.ts
+++ b/src/applications/addressbook/addressbook-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AbDetailEditor</name>
     <message>

--- a/src/applications/addressbook/addressbook-de_DE.ts
+++ b/src/applications/addressbook/addressbook-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AbDetailEditor</name>
     <message>

--- a/src/applications/addressbook/addressbook-en_US.ts
+++ b/src/applications/addressbook/addressbook-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>ReminderPicker</name>
     <message numerus="yes">

--- a/src/applications/addressbook/addressbook-es_ES.ts
+++ b/src/applications/addressbook/addressbook-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AbDetailEditor</name>
     <message>

--- a/src/applications/addressbook/addressbook-it_IT.ts
+++ b/src/applications/addressbook/addressbook-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AbDetailEditor</name>
     <message>

--- a/src/applications/addressbook/addressbook-pl_PL.ts
+++ b/src/applications/addressbook/addressbook-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AbDetailEditor</name>
     <message>

--- a/src/applications/bluetooth/bluetooth-da_DK.ts
+++ b/src/applications/bluetooth/bluetooth-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>BtFtp</name>
     <message>

--- a/src/applications/bluetooth/bluetooth-de_DE.ts
+++ b/src/applications/bluetooth/bluetooth-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>BtFtp</name>
     <message>

--- a/src/applications/bluetooth/bluetooth-en_US.ts
+++ b/src/applications/bluetooth/bluetooth-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/applications/bluetooth/bluetooth-es_ES.ts
+++ b/src/applications/bluetooth/bluetooth-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>BtFtp</name>
     <message>

--- a/src/applications/bluetooth/bluetooth-it_IT.ts
+++ b/src/applications/bluetooth/bluetooth-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>BtFtp</name>
     <message>

--- a/src/applications/bluetooth/bluetooth-pl_PL.ts
+++ b/src/applications/bluetooth/bluetooth-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>BtFtp</name>
     <message>

--- a/src/applications/calculator/calculator-da_DK.ts
+++ b/src/applications/calculator/calculator-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>Calculator</name>
     <message>

--- a/src/applications/calculator/calculator-de_DE.ts
+++ b/src/applications/calculator/calculator-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>Calculator</name>
     <message>

--- a/src/applications/calculator/calculator-en_US.ts
+++ b/src/applications/calculator/calculator-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/applications/calculator/calculator-es_ES.ts
+++ b/src/applications/calculator/calculator-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Calculator</name>
     <message>

--- a/src/applications/calculator/calculator-fr_FR.ts
+++ b/src/applications/calculator/calculator-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>Calculator</name>
     <message>

--- a/src/applications/calculator/calculator-it_IT.ts
+++ b/src/applications/calculator/calculator-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Calculator</name>
     <message>

--- a/src/applications/calculator/calculator-pl_PL.ts
+++ b/src/applications/calculator/calculator-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>Calculator</name>
     <message>

--- a/src/applications/camera/camera-fr_FR.ts
+++ b/src/applications/camera/camera-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>CameraBase</name>
     <message>

--- a/src/applications/camera/camera-it_IT.ts
+++ b/src/applications/camera/camera-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>CameraBase</name>
     <message>

--- a/src/applications/clock/clock-da_DK.ts
+++ b/src/applications/clock/clock-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>Alarm</name>
     <message>

--- a/src/applications/clock/clock-de_DE.ts
+++ b/src/applications/clock/clock-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>Alarm</name>
     <message>

--- a/src/applications/clock/clock-en_US.ts
+++ b/src/applications/clock/clock-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/applications/clock/clock-es_ES.ts
+++ b/src/applications/clock/clock-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Alarm</name>
     <message>

--- a/src/applications/clock/clock-it_IT.ts
+++ b/src/applications/clock/clock-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Alarm</name>
     <message>

--- a/src/applications/clock/clock-pl_PL.ts
+++ b/src/applications/clock/clock-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>Alarm</name>
     <message>

--- a/src/applications/datebook/datebook-da_DK.ts
+++ b/src/applications/datebook/datebook-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AccountEditor</name>
     <message>

--- a/src/applications/datebook/datebook-de_DE.ts
+++ b/src/applications/datebook/datebook-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AccountEditor</name>
     <message>

--- a/src/applications/datebook/datebook-en_US.ts
+++ b/src/applications/datebook/datebook-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>AppointmentDetails</name>
     <message numerus="yes">

--- a/src/applications/datebook/datebook-es_ES.ts
+++ b/src/applications/datebook/datebook-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AccountEditor</name>
     <message>

--- a/src/applications/datebook/datebook-fr_FR.ts
+++ b/src/applications/datebook/datebook-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>AccountEditor</name>
     <message>

--- a/src/applications/datebook/datebook-it_IT.ts
+++ b/src/applications/datebook/datebook-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AccountEditor</name>
     <message>

--- a/src/applications/datebook/datebook-pl_PL.ts
+++ b/src/applications/datebook/datebook-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AccountEditor</name>
     <message>

--- a/src/applications/helpbrowser/helpbrowser-cs_CZ.ts
+++ b/src/applications/helpbrowser/helpbrowser-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>HelpBrowser</name>
     <message>

--- a/src/applications/helpbrowser/helpbrowser-da_DK.ts
+++ b/src/applications/helpbrowser/helpbrowser-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>HelpBrowser</name>
     <message>

--- a/src/applications/helpbrowser/helpbrowser-de_DE.ts
+++ b/src/applications/helpbrowser/helpbrowser-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>HelpBrowser</name>
     <message>

--- a/src/applications/helpbrowser/helpbrowser-en_US.ts
+++ b/src/applications/helpbrowser/helpbrowser-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/applications/helpbrowser/helpbrowser-es_ES.ts
+++ b/src/applications/helpbrowser/helpbrowser-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>HelpBrowser</name>
     <message>

--- a/src/applications/helpbrowser/helpbrowser-it_IT.ts
+++ b/src/applications/helpbrowser/helpbrowser-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>HelpBrowser</name>
     <message>

--- a/src/applications/helpbrowser/helpbrowser-pl_PL.ts
+++ b/src/applications/helpbrowser/helpbrowser-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>HelpBrowser</name>
     <message>

--- a/src/applications/mediaplayer/mediaplayer-da_DK.ts
+++ b/src/applications/mediaplayer/mediaplayer-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>HelpDirector</name>
     <message>

--- a/src/applications/mediaplayer/mediaplayer-de_DE.ts
+++ b/src/applications/mediaplayer/mediaplayer-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>HelpDirector</name>
     <message>

--- a/src/applications/mediaplayer/mediaplayer-en_US.ts
+++ b/src/applications/mediaplayer/mediaplayer-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/applications/mediaplayer/mediaplayer-es_ES.ts
+++ b/src/applications/mediaplayer/mediaplayer-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>HelpDirector</name>
     <message>

--- a/src/applications/mediaplayer/mediaplayer-it_IT.ts
+++ b/src/applications/mediaplayer/mediaplayer-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>HelpDirector</name>
     <message>

--- a/src/applications/mediaplayer/mediaplayer-pl_PL.ts
+++ b/src/applications/mediaplayer/mediaplayer-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>HelpDirector</name>
     <message>

--- a/src/applications/mediarecorder/mediarecorder-da_DK.ts
+++ b/src/applications/mediarecorder/mediarecorder-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>ConfigureRecorder</name>
     <message>

--- a/src/applications/mediarecorder/mediarecorder-de_DE.ts
+++ b/src/applications/mediarecorder/mediarecorder-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>ConfigureRecorder</name>
     <message>

--- a/src/applications/mediarecorder/mediarecorder-en_US.ts
+++ b/src/applications/mediarecorder/mediarecorder-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/applications/mediarecorder/mediarecorder-es_ES.ts
+++ b/src/applications/mediarecorder/mediarecorder-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>ConfigureRecorder</name>
     <message>

--- a/src/applications/mediarecorder/mediarecorder-it_IT.ts
+++ b/src/applications/mediarecorder/mediarecorder-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>ConfigureRecorder</name>
     <message>

--- a/src/applications/mediarecorder/mediarecorder-pl_PL.ts
+++ b/src/applications/mediarecorder/mediarecorder-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>ConfigureRecorder</name>
     <message>

--- a/src/applications/photoedit/photoedit-cs_CZ.ts
+++ b/src/applications/photoedit/photoedit-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>EffectDialog</name>
     <message>

--- a/src/applications/photoedit/photoedit-da_DK.ts
+++ b/src/applications/photoedit/photoedit-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>EffectDialog</name>
     <message>

--- a/src/applications/photoedit/photoedit-de_DE.ts
+++ b/src/applications/photoedit/photoedit-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>EffectDialog</name>
     <message>

--- a/src/applications/photoedit/photoedit-en_US.ts
+++ b/src/applications/photoedit/photoedit-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/applications/photoedit/photoedit-es_ES.ts
+++ b/src/applications/photoedit/photoedit-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>EffectDialog</name>
     <message>

--- a/src/applications/photoedit/photoedit-fr_FR.ts
+++ b/src/applications/photoedit/photoedit-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>EffectDialog</name>
     <message>

--- a/src/applications/photoedit/photoedit-it_IT.ts
+++ b/src/applications/photoedit/photoedit-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>EffectDialog</name>
     <message>

--- a/src/applications/photoedit/photoedit-pl_PL.ts
+++ b/src/applications/photoedit/photoedit-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>EffectDialog</name>
     <message>

--- a/src/applications/qtmail/qtmail-da_DK.ts
+++ b/src/applications/qtmail/qtmail-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AccountSettings</name>
     <message>

--- a/src/applications/qtmail/qtmail-de_DE.ts
+++ b/src/applications/qtmail/qtmail-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AccountSettings</name>
     <message>

--- a/src/applications/qtmail/qtmail-en_US.ts
+++ b/src/applications/qtmail/qtmail-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>EmailClient</name>
     <message numerus="yes">

--- a/src/applications/qtmail/qtmail-es_ES.ts
+++ b/src/applications/qtmail/qtmail-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AccountSettings</name>
     <message>

--- a/src/applications/qtmail/qtmail-it_IT.ts
+++ b/src/applications/qtmail/qtmail-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AccountSettings</name>
     <message>

--- a/src/applications/qtmail/qtmail-pl_PL.ts
+++ b/src/applications/qtmail/qtmail-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AccountSettings</name>
     <message>

--- a/src/applications/sysinfo/sysinfo-da_DK.ts
+++ b/src/applications/sysinfo/sysinfo-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>CleanupWizard</name>
     <message numerus="yes">

--- a/src/applications/sysinfo/sysinfo-de_DE.ts
+++ b/src/applications/sysinfo/sysinfo-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>CleanupWizard</name>
     <message numerus="yes">

--- a/src/applications/sysinfo/sysinfo-en_US.ts
+++ b/src/applications/sysinfo/sysinfo-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>CleanupWizard</name>
     <message numerus="yes">

--- a/src/applications/sysinfo/sysinfo-es_ES.ts
+++ b/src/applications/sysinfo/sysinfo-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>CleanupWizard</name>
     <message numerus="yes">

--- a/src/applications/sysinfo/sysinfo-fr_FR.ts
+++ b/src/applications/sysinfo/sysinfo-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>CleanupWizard</name>
     <message numerus="yes">

--- a/src/applications/sysinfo/sysinfo-it_IT.ts
+++ b/src/applications/sysinfo/sysinfo-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>CleanupWizard</name>
     <message numerus="yes">

--- a/src/applications/sysinfo/sysinfo-pl_PL.ts
+++ b/src/applications/sysinfo/sysinfo-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>CleanupWizard</name>
     <message numerus="yes">

--- a/src/applications/textedit/textedit-da_DK.ts
+++ b/src/applications/textedit/textedit-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>TextCodecSelector</name>
     <message>

--- a/src/applications/textedit/textedit-de_DE.ts
+++ b/src/applications/textedit/textedit-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>TextCodecSelector</name>
     <message>

--- a/src/applications/textedit/textedit-en_US.ts
+++ b/src/applications/textedit/textedit-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/applications/textedit/textedit-es_ES.ts
+++ b/src/applications/textedit/textedit-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>TextCodecSelector</name>
     <message>

--- a/src/applications/textedit/textedit-it_IT.ts
+++ b/src/applications/textedit/textedit-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>TextCodecSelector</name>
     <message>

--- a/src/applications/textedit/textedit-pl_PL.ts
+++ b/src/applications/textedit/textedit-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>TextCodecSelector</name>
     <message>

--- a/src/applications/todo/todolist-cs_CZ.ts
+++ b/src/applications/todo/todolist-cs_CZ.ts
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/applications/todolist/todolist-cs_CZ.ts
+++ b/src/applications/todolist/todolist-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/applications/todolist/todolist-da_DK.ts
+++ b/src/applications/todolist/todolist-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/applications/todolist/todolist-de_DE.ts
+++ b/src/applications/todolist/todolist-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/applications/todolist/todolist-en_US.ts
+++ b/src/applications/todolist/todolist-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>ReminderPicker</name>
     <message numerus="yes">

--- a/src/applications/todolist/todolist-es_ES.ts
+++ b/src/applications/todolist/todolist-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/applications/todolist/todolist-fr_FR.ts
+++ b/src/applications/todolist/todolist-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/applications/todolist/todolist-it_IT.ts
+++ b/src/applications/todolist/todolist-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/applications/todolist/todolist-pl_PL.ts
+++ b/src/applications/todolist/todolist-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/applications/todolist/todolist-ru_RU.ts
+++ b/src/applications/todolist/todolist-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>ListPositionBar</name>
     <message>

--- a/src/games/fifteen/fifteen-da_DK.ts
+++ b/src/games/fifteen/fifteen-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>FifteenMainWindow</name>
     <message>

--- a/src/games/fifteen/fifteen-de_DE.ts
+++ b/src/games/fifteen/fifteen-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>FifteenMainWindow</name>
     <message>

--- a/src/games/fifteen/fifteen-en_US.ts
+++ b/src/games/fifteen/fifteen-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/games/fifteen/fifteen-es_ES.ts
+++ b/src/games/fifteen/fifteen-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>FifteenMainWindow</name>
     <message>

--- a/src/games/fifteen/fifteen-fr_FR.ts
+++ b/src/games/fifteen/fifteen-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>FifteenMainWindow</name>
     <message>

--- a/src/games/fifteen/fifteen-it_IT.ts
+++ b/src/games/fifteen/fifteen-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>FifteenMainWindow</name>
     <message>

--- a/src/games/fifteen/fifteen-pl_PL.ts
+++ b/src/games/fifteen/fifteen-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>FifteenMainWindow</name>
     <message>

--- a/src/games/mindbreaker/mindbreaker-cs_CZ.ts
+++ b/src/games/mindbreaker/mindbreaker-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>MindBreaker</name>
     <message>

--- a/src/games/mindbreaker/mindbreaker-da_DK.ts
+++ b/src/games/mindbreaker/mindbreaker-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>MindBreaker</name>
     <message>

--- a/src/games/mindbreaker/mindbreaker-de_DE.ts
+++ b/src/games/mindbreaker/mindbreaker-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>MindBreaker</name>
     <message>

--- a/src/games/mindbreaker/mindbreaker-en_US.ts
+++ b/src/games/mindbreaker/mindbreaker-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/games/mindbreaker/mindbreaker-es_ES.ts
+++ b/src/games/mindbreaker/mindbreaker-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>MindBreaker</name>
     <message>

--- a/src/games/mindbreaker/mindbreaker-it_IT.ts
+++ b/src/games/mindbreaker/mindbreaker-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>MindBreaker</name>
     <message>

--- a/src/games/mindbreaker/mindbreaker-pl_PL.ts
+++ b/src/games/mindbreaker/mindbreaker-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>MindBreaker</name>
     <message>

--- a/src/games/mindbreaker/mindbreaker-ru_RU.ts
+++ b/src/games/mindbreaker/mindbreaker-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>MindBreaker</name>
     <message>

--- a/src/games/minesweep/minesweep-da_DK.ts
+++ b/src/games/minesweep/minesweep-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>MineSweep</name>
     <message>

--- a/src/games/minesweep/minesweep-de_DE.ts
+++ b/src/games/minesweep/minesweep-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>MineSweep</name>
     <message>

--- a/src/games/minesweep/minesweep-en_US.ts
+++ b/src/games/minesweep/minesweep-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/games/minesweep/minesweep-es_ES.ts
+++ b/src/games/minesweep/minesweep-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>MineSweep</name>
     <message>

--- a/src/games/minesweep/minesweep-it_IT.ts
+++ b/src/games/minesweep/minesweep-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>MineSweep</name>
     <message>

--- a/src/games/minesweep/minesweep-pl_PL.ts
+++ b/src/games/minesweep/minesweep-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>MineSweep</name>
     <message>

--- a/src/games/parashoot/parashoot-fr_FR.ts
+++ b/src/games/parashoot/parashoot-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>ParaShoot</name>
     <message>

--- a/src/games/qasteroids/qasteroids-fr_FR.ts
+++ b/src/games/qasteroids/qasteroids-fr_FR.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="fr_FR">
 <context>
     <name>KAstTopLevel</name>
     <message>

--- a/src/games/snake/snake-da_DK.ts
+++ b/src/games/snake/snake-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>SnakeGame</name>
     <message>

--- a/src/games/snake/snake-de_DE.ts
+++ b/src/games/snake/snake-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>SnakeGame</name>
     <message>

--- a/src/games/snake/snake-en_US.ts
+++ b/src/games/snake/snake-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/games/snake/snake-es_ES.ts
+++ b/src/games/snake/snake-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>SnakeGame</name>
     <message>

--- a/src/games/snake/snake-it_IT.ts
+++ b/src/games/snake/snake-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>SnakeGame</name>
     <message>

--- a/src/games/snake/snake-pl_PL.ts
+++ b/src/games/snake/snake-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>SnakeGame</name>
     <message>

--- a/src/libraries/handwriting/libqmstroke-da_DK.ts
+++ b/src/libraries/handwriting/libqmstroke-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>Handwriting</name>
     <message>

--- a/src/libraries/handwriting/libqmstroke-de_DE.ts
+++ b/src/libraries/handwriting/libqmstroke-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>Handwriting</name>
     <message>

--- a/src/libraries/handwriting/libqmstroke-en_US.ts
+++ b/src/libraries/handwriting/libqmstroke-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/handwriting/libqmstroke-es_ES.ts
+++ b/src/libraries/handwriting/libqmstroke-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Handwriting</name>
     <message>

--- a/src/libraries/handwriting/libqmstroke-it_IT.ts
+++ b/src/libraries/handwriting/libqmstroke-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Handwriting</name>
     <message>

--- a/src/libraries/handwriting/libqmstroke-pl_PL.ts
+++ b/src/libraries/handwriting/libqmstroke-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>Handwriting</name>
     <message>

--- a/src/libraries/qtopia/libqtopia-da_DK.ts
+++ b/src/libraries/qtopia/libqtopia-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AudioDocumentSelectorDialog</name>
     <message>

--- a/src/libraries/qtopia/libqtopia-de_DE.ts
+++ b/src/libraries/qtopia/libqtopia-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AudioDocumentSelectorDialog</name>
     <message>

--- a/src/libraries/qtopia/libqtopia-en_US.ts
+++ b/src/libraries/qtopia/libqtopia-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/qtopia/libqtopia-es_ES.ts
+++ b/src/libraries/qtopia/libqtopia-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AudioDocumentSelectorDialog</name>
     <message>

--- a/src/libraries/qtopia/libqtopia-fr_FR.ts
+++ b/src/libraries/qtopia/libqtopia-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>AudioDocumentSelectorDialog</name>
     <message>

--- a/src/libraries/qtopia/libqtopia-it_IT.ts
+++ b/src/libraries/qtopia/libqtopia-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AudioDocumentSelectorDialog</name>
     <message>

--- a/src/libraries/qtopia/libqtopia-pl_PL.ts
+++ b/src/libraries/qtopia/libqtopia-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AudioDocumentSelectorDialog</name>
     <message>

--- a/src/libraries/qtopia/timezone-cs_CZ.ts
+++ b/src/libraries/qtopia/timezone-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>QTimeZone</name>
     <message>

--- a/src/libraries/qtopia/timezone-da_DK.ts
+++ b/src/libraries/qtopia/timezone-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>QTimeZone</name>
     <message>

--- a/src/libraries/qtopia/timezone-de_DE.ts
+++ b/src/libraries/qtopia/timezone-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>QTimeZone</name>
     <message>

--- a/src/libraries/qtopia/timezone-en_US.ts
+++ b/src/libraries/qtopia/timezone-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/qtopia/timezone-es_ES.ts
+++ b/src/libraries/qtopia/timezone-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>QTimeZone</name>
     <message>

--- a/src/libraries/qtopia/timezone-fr_FR.ts
+++ b/src/libraries/qtopia/timezone-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>QTimeZone</name>
     <message>

--- a/src/libraries/qtopia/timezone-it_IT.ts
+++ b/src/libraries/qtopia/timezone-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QTimeZone</name>
     <message>

--- a/src/libraries/qtopia/timezone-pl_PL.ts
+++ b/src/libraries/qtopia/timezone-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>QTimeZone</name>
     <message>

--- a/src/libraries/qtopiabase/libqtopiabase-da_DK.ts
+++ b/src/libraries/qtopiabase/libqtopiabase-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/libraries/qtopiabase/libqtopiabase-de_DE.ts
+++ b/src/libraries/qtopiabase/libqtopiabase-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/libraries/qtopiabase/libqtopiabase-en_US.ts
+++ b/src/libraries/qtopiabase/libqtopiabase-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/qtopiabase/libqtopiabase-es_ES.ts
+++ b/src/libraries/qtopiabase/libqtopiabase-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/libraries/qtopiabase/libqtopiabase-it_IT.ts
+++ b/src/libraries/qtopiabase/libqtopiabase-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/libraries/qtopiabase/libqtopiabase-pl_PL.ts
+++ b/src/libraries/qtopiabase/libqtopiabase-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/libraries/qtopiacomm/libqtopiacomm-cs_CZ.ts
+++ b/src/libraries/qtopiacomm/libqtopiacomm-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>AccountPage</name>
     <message>

--- a/src/libraries/qtopiacomm/libqtopiacomm-da_DK.ts
+++ b/src/libraries/qtopiacomm/libqtopiacomm-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AccountPage</name>
     <message>

--- a/src/libraries/qtopiacomm/libqtopiacomm-de_DE.ts
+++ b/src/libraries/qtopiacomm/libqtopiacomm-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AccountPage</name>
     <message>

--- a/src/libraries/qtopiacomm/libqtopiacomm-en_US.ts
+++ b/src/libraries/qtopiacomm/libqtopiacomm-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/qtopiacomm/libqtopiacomm-es_ES.ts
+++ b/src/libraries/qtopiacomm/libqtopiacomm-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AccountPage</name>
     <message>

--- a/src/libraries/qtopiacomm/libqtopiacomm-fr_FR.ts
+++ b/src/libraries/qtopiacomm/libqtopiacomm-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>AccountPage</name>
     <message>

--- a/src/libraries/qtopiacomm/libqtopiacomm-it_IT.ts
+++ b/src/libraries/qtopiacomm/libqtopiacomm-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AccountPage</name>
     <message>

--- a/src/libraries/qtopiacomm/libqtopiacomm-pl_PL.ts
+++ b/src/libraries/qtopiacomm/libqtopiacomm-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AccountPage</name>
     <message>

--- a/src/libraries/qtopiacore/qt-it_IT.ts
+++ b/src/libraries/qtopiacore/qt-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AudioOutput</name>
     <message>

--- a/src/libraries/qtopiamail/libqtopiamail-da_DK.ts
+++ b/src/libraries/qtopiamail/libqtopiamail-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AddressSelectorWidget</name>
     <message>

--- a/src/libraries/qtopiamail/libqtopiamail-de_DE.ts
+++ b/src/libraries/qtopiamail/libqtopiamail-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AddressSelectorWidget</name>
     <message>

--- a/src/libraries/qtopiamail/libqtopiamail-en_US.ts
+++ b/src/libraries/qtopiamail/libqtopiamail-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/qtopiamail/libqtopiamail-es_ES.ts
+++ b/src/libraries/qtopiamail/libqtopiamail-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AddressSelectorWidget</name>
     <message>

--- a/src/libraries/qtopiamail/libqtopiamail-it_IT.ts
+++ b/src/libraries/qtopiamail/libqtopiamail-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AddressSelectorWidget</name>
     <message>

--- a/src/libraries/qtopiamail/libqtopiamail-pl_PL.ts
+++ b/src/libraries/qtopiamail/libqtopiamail-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AddressSelectorWidget</name>
     <message>

--- a/src/libraries/qtopiaphone/libqtopiaphone-cs_CZ.ts
+++ b/src/libraries/qtopiaphone/libqtopiaphone-cs_CZ.ts
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 </TS>

--- a/src/libraries/qtopiapim/libqtopiapim-da_DK.ts
+++ b/src/libraries/qtopiapim/libqtopiapim-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>QAppointmentDefaultContext</name>
     <message>

--- a/src/libraries/qtopiapim/libqtopiapim-de_DE.ts
+++ b/src/libraries/qtopiapim/libqtopiapim-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>QAppointmentDefaultContext</name>
     <message>

--- a/src/libraries/qtopiapim/libqtopiapim-en_US.ts
+++ b/src/libraries/qtopiapim/libqtopiapim-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/qtopiapim/libqtopiapim-es_ES.ts
+++ b/src/libraries/qtopiapim/libqtopiapim-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>QAppointmentDefaultContext</name>
     <message>

--- a/src/libraries/qtopiapim/libqtopiapim-it_IT.ts
+++ b/src/libraries/qtopiapim/libqtopiapim-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QAppointmentDefaultContext</name>
     <message>

--- a/src/libraries/qtopiapim/libqtopiapim-pl_PL.ts
+++ b/src/libraries/qtopiapim/libqtopiapim-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>QAppointmentDefaultContext</name>
     <message>

--- a/src/libraries/qtopiaprinting/libqtopiaprinting-cs_CZ.ts
+++ b/src/libraries/qtopiaprinting/libqtopiaprinting-cs_CZ.ts
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 <context>
     <name>PrintDialogBase</name>
     <message>

--- a/src/libraries/qtopiatheming/libqtopiatheming-cs_CZ.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-cs_CZ.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 </TS>

--- a/src/libraries/qtopiatheming/libqtopiatheming-da_DK.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-da_DK.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 </TS>

--- a/src/libraries/qtopiatheming/libqtopiatheming-de_DE.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-de_DE.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 </TS>

--- a/src/libraries/qtopiatheming/libqtopiatheming-en_US.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/qtopiatheming/libqtopiatheming-es_ES.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-es_ES.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 </TS>

--- a/src/libraries/qtopiatheming/libqtopiatheming-fr_FR.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-fr_FR.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 </TS>

--- a/src/libraries/qtopiatheming/libqtopiatheming-it_IT.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-it_IT.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 </TS>

--- a/src/libraries/qtopiatheming/libqtopiatheming-pl_PL.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-pl_PL.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 </TS>

--- a/src/libraries/qtopiatheming/libqtopiatheming-ru_RU.ts
+++ b/src/libraries/qtopiatheming/libqtopiatheming-ru_RU.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 </TS>

--- a/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-cs_CZ.ts
+++ b/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>QObject</name>
     <message>

--- a/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-da_DK.ts
+++ b/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>QObject</name>
     <message>

--- a/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-de_DE.ts
+++ b/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>QObject</name>
     <message>

--- a/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-en_US.ts
+++ b/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-es_ES.ts
+++ b/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>QObject</name>
     <message>

--- a/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-it_IT.ts
+++ b/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QObject</name>
     <message>

--- a/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-pl_PL.ts
+++ b/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>QObject</name>
     <message>

--- a/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-ru_RU.ts
+++ b/src/libraries/qtopiawhereabouts/libqtopiawhereabouts-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>QObject</name>
     <message>

--- a/src/plugins/audiohardware/desktop/libdesktopaudiohardware-fr_FR.ts
+++ b/src/plugins/audiohardware/desktop/libdesktopaudiohardware-fr_FR.ts
@@ -1,4 +1,4 @@
-<!DOCTYPE TS><TS>
+<!DOCTYPE TS><TS language="fr_FR">
 <context>
     <name>BluetoothAudioState</name>
     <message>

--- a/src/plugins/audiohardware/desktop/libdesktopaudiohardware-it_IT.ts
+++ b/src/plugins/audiohardware/desktop/libdesktopaudiohardware-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>BluetoothAudioState</name>
     <message>

--- a/src/plugins/composers/email/libemailcomposer-da_DK.ts
+++ b/src/plugins/composers/email/libemailcomposer-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AddAtt</name>
     <message>

--- a/src/plugins/composers/email/libemailcomposer-de_DE.ts
+++ b/src/plugins/composers/email/libemailcomposer-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AddAtt</name>
     <message>

--- a/src/plugins/composers/email/libemailcomposer-en_US.ts
+++ b/src/plugins/composers/email/libemailcomposer-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>EmailComposerInterface</name>
     <message numerus="yes">

--- a/src/plugins/composers/email/libemailcomposer-es_ES.ts
+++ b/src/plugins/composers/email/libemailcomposer-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AddAtt</name>
     <message>

--- a/src/plugins/composers/email/libemailcomposer-it_IT.ts
+++ b/src/plugins/composers/email/libemailcomposer-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AddAtt</name>
     <message>

--- a/src/plugins/composers/email/libemailcomposer-pl_PL.ts
+++ b/src/plugins/composers/email/libemailcomposer-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AddAtt</name>
     <message>

--- a/src/plugins/composers/generic/libgenericcomposer-da_DK.ts
+++ b/src/plugins/composers/generic/libgenericcomposer-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>GenericComposerInterface</name>
     <message>

--- a/src/plugins/composers/generic/libgenericcomposer-de_DE.ts
+++ b/src/plugins/composers/generic/libgenericcomposer-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>GenericComposerInterface</name>
     <message>

--- a/src/plugins/composers/generic/libgenericcomposer-en_US.ts
+++ b/src/plugins/composers/generic/libgenericcomposer-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/composers/generic/libgenericcomposer-es_ES.ts
+++ b/src/plugins/composers/generic/libgenericcomposer-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>GenericComposerInterface</name>
     <message>

--- a/src/plugins/composers/generic/libgenericcomposer-it_IT.ts
+++ b/src/plugins/composers/generic/libgenericcomposer-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>GenericComposerInterface</name>
     <message>

--- a/src/plugins/composers/generic/libgenericcomposer-pl_PL.ts
+++ b/src/plugins/composers/generic/libgenericcomposer-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>GenericComposerInterface</name>
     <message>

--- a/src/plugins/composers/mms/libmmscomposer-da_DK.ts
+++ b/src/plugins/composers/mms/libmmscomposer-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>MMSComposerInterface</name>
     <message>

--- a/src/plugins/composers/mms/libmmscomposer-de_DE.ts
+++ b/src/plugins/composers/mms/libmmscomposer-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>MMSComposerInterface</name>
     <message>

--- a/src/plugins/composers/mms/libmmscomposer-en_US.ts
+++ b/src/plugins/composers/mms/libmmscomposer-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/composers/mms/libmmscomposer-es_ES.ts
+++ b/src/plugins/composers/mms/libmmscomposer-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>MMSComposerInterface</name>
     <message>

--- a/src/plugins/composers/mms/libmmscomposer-it_IT.ts
+++ b/src/plugins/composers/mms/libmmscomposer-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>MMSComposerInterface</name>
     <message>

--- a/src/plugins/composers/mms/libmmscomposer-pl_PL.ts
+++ b/src/plugins/composers/mms/libmmscomposer-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>MMSComposerInterface</name>
     <message>

--- a/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-cs_CZ.ts
+++ b/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>DictFilterConfig</name>
     <message>

--- a/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-da_DK.ts
+++ b/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>DictFilterConfig</name>
     <message>

--- a/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-de_DE.ts
+++ b/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>DictFilterConfig</name>
     <message>

--- a/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-en_US.ts
+++ b/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-es_ES.ts
+++ b/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>DictFilterConfig</name>
     <message>

--- a/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-it_IT.ts
+++ b/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>DictFilterConfig</name>
     <message>

--- a/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-pl_PL.ts
+++ b/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>DictFilterConfig</name>
     <message>

--- a/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-ru_RU.ts
+++ b/src/plugins/inputmethods/fingerkeyboard/libfingerkeyboard-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>DictFilterConfig</name>
     <message>

--- a/src/plugins/inputmethods/predictivekeyboard/libqpredictivekeyboard-ru_RU.ts
+++ b/src/plugins/inputmethods/predictivekeyboard/libqpredictivekeyboard-ru_RU.ts
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="ru_RU">
 <context>
     <name>InputMethods</name>
     <message>

--- a/src/plugins/network/bluetooth/libbluetooth-cs_CZ.ts
+++ b/src/plugins/network/bluetooth/libbluetooth-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>AdvancedBtBase</name>
     <message>

--- a/src/plugins/network/bluetooth/libbluetooth-da_DK.ts
+++ b/src/plugins/network/bluetooth/libbluetooth-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AdvancedBtBase</name>
     <message>

--- a/src/plugins/network/bluetooth/libbluetooth-de_DE.ts
+++ b/src/plugins/network/bluetooth/libbluetooth-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AdvancedBtBase</name>
     <message>

--- a/src/plugins/network/bluetooth/libbluetooth-en_US.ts
+++ b/src/plugins/network/bluetooth/libbluetooth-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/network/bluetooth/libbluetooth-es_ES.ts
+++ b/src/plugins/network/bluetooth/libbluetooth-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AdvancedBtBase</name>
     <message>

--- a/src/plugins/network/bluetooth/libbluetooth-it_IT.ts
+++ b/src/plugins/network/bluetooth/libbluetooth-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AdvancedBtBase</name>
     <message>

--- a/src/plugins/network/bluetooth/libbluetooth-pl_PL.ts
+++ b/src/plugins/network/bluetooth/libbluetooth-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AdvancedBtBase</name>
     <message>

--- a/src/plugins/network/dialing/libdialing-da_DK.ts
+++ b/src/plugins/network/dialing/libdialing-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AdvancedBase</name>
     <message>

--- a/src/plugins/network/dialing/libdialing-de_DE.ts
+++ b/src/plugins/network/dialing/libdialing-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AdvancedBase</name>
     <message>

--- a/src/plugins/network/dialing/libdialing-en_US.ts
+++ b/src/plugins/network/dialing/libdialing-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/network/dialing/libdialing-es_ES.ts
+++ b/src/plugins/network/dialing/libdialing-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AdvancedBase</name>
     <message>

--- a/src/plugins/network/dialing/libdialing-it_IT.ts
+++ b/src/plugins/network/dialing/libdialing-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AdvancedBase</name>
     <message>

--- a/src/plugins/network/dialing/libdialing-pl_PL.ts
+++ b/src/plugins/network/dialing/libdialing-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AdvancedBase</name>
     <message>

--- a/src/plugins/network/lan/liblan-cs_CZ.ts
+++ b/src/plugins/network/lan/liblan-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>ChooseNetworkUI</name>
     <message>

--- a/src/plugins/network/lan/liblan-da_DK.ts
+++ b/src/plugins/network/lan/liblan-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>ChooseNetworkUI</name>
     <message>

--- a/src/plugins/network/lan/liblan-de_DE.ts
+++ b/src/plugins/network/lan/liblan-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>ChooseNetworkUI</name>
     <message>

--- a/src/plugins/network/lan/liblan-en_US.ts
+++ b/src/plugins/network/lan/liblan-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/network/lan/liblan-es_ES.ts
+++ b/src/plugins/network/lan/liblan-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>ChooseNetworkUI</name>
     <message>

--- a/src/plugins/network/lan/liblan-it_IT.ts
+++ b/src/plugins/network/lan/liblan-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>ChooseNetworkUI</name>
     <message>

--- a/src/plugins/network/lan/liblan-pl_PL.ts
+++ b/src/plugins/network/lan/liblan-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>ChooseNetworkUI</name>
     <message>

--- a/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-cs_CZ.ts
+++ b/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>BluetoothPrinterPlugin</name>
     <message>

--- a/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-da_DK.ts
+++ b/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>BluetoothPrinterPlugin</name>
     <message>

--- a/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-de_DE.ts
+++ b/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>BluetoothPrinterPlugin</name>
     <message>

--- a/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-en_US.ts
+++ b/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-es_ES.ts
+++ b/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>BluetoothPrinterPlugin</name>
     <message>

--- a/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-fr_FR.ts
+++ b/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>BluetoothPrinterPlugin</name>
     <message>

--- a/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-it_IT.ts
+++ b/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>BluetoothPrinterPlugin</name>
     <message>

--- a/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-pl_PL.ts
+++ b/src/plugins/qtopiaprinting/bluetooth/libbluetoothprinting-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>BluetoothPrinterPlugin</name>
     <message>

--- a/src/plugins/viewers/conversation/libconversationviewer-cs_CZ.ts
+++ b/src/plugins/viewers/conversation/libconversationviewer-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>ConversationViewer</name>
     <message>

--- a/src/plugins/viewers/conversation/libconversationviewer-da_DK.ts
+++ b/src/plugins/viewers/conversation/libconversationviewer-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>ConversationViewer</name>
     <message>

--- a/src/plugins/viewers/conversation/libconversationviewer-de_DE.ts
+++ b/src/plugins/viewers/conversation/libconversationviewer-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>ConversationViewer</name>
     <message>

--- a/src/plugins/viewers/conversation/libconversationviewer-en_US.ts
+++ b/src/plugins/viewers/conversation/libconversationviewer-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/viewers/conversation/libconversationviewer-es_ES.ts
+++ b/src/plugins/viewers/conversation/libconversationviewer-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>ConversationViewer</name>
     <message>

--- a/src/plugins/viewers/conversation/libconversationviewer-it_IT.ts
+++ b/src/plugins/viewers/conversation/libconversationviewer-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>ConversationViewer</name>
     <message>

--- a/src/plugins/viewers/conversation/libconversationviewer-pl_PL.ts
+++ b/src/plugins/viewers/conversation/libconversationviewer-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>ConversationViewer</name>
     <message>

--- a/src/plugins/viewers/conversation/libconversationviewer-ru_RU.ts
+++ b/src/plugins/viewers/conversation/libconversationviewer-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>ConversationViewer</name>
     <message>

--- a/src/plugins/viewers/generic/libgenericviewer-da_DK.ts
+++ b/src/plugins/viewers/generic/libgenericviewer-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AttachmentOptions</name>
     <message>

--- a/src/plugins/viewers/generic/libgenericviewer-de_DE.ts
+++ b/src/plugins/viewers/generic/libgenericviewer-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AttachmentOptions</name>
     <message>

--- a/src/plugins/viewers/generic/libgenericviewer-en_US.ts
+++ b/src/plugins/viewers/generic/libgenericviewer-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/plugins/viewers/generic/libgenericviewer-es_ES.ts
+++ b/src/plugins/viewers/generic/libgenericviewer-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AttachmentOptions</name>
     <message>

--- a/src/plugins/viewers/generic/libgenericviewer-it_IT.ts
+++ b/src/plugins/viewers/generic/libgenericviewer-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AttachmentOptions</name>
     <message>

--- a/src/plugins/viewers/generic/libgenericviewer-pl_PL.ts
+++ b/src/plugins/viewers/generic/libgenericviewer-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AttachmentOptions</name>
     <message>

--- a/src/plugins/viewers/smil/libsmilviewer-cs_CZ.ts
+++ b/src/plugins/viewers/smil/libsmilviewer-cs_CZ.ts
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 </TS>

--- a/src/plugins/viewers/smil/libsmilviewer-ru_RU.ts
+++ b/src/plugins/viewers/smil/libsmilviewer-ru_RU.ts
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="ru_RU">
 </TS>

--- a/src/qt/qt-fr_FR.ts
+++ b/src/qt/qt-fr_FR.ts
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0" language="fr_FR">
+<TS version="2.0">
 <context>
     <name>AudioOutput</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/audiooutput.cpp" line="375"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/audiooutput.cpp" line="375"/>
         <source>&lt;html&gt;The audio playback device &lt;b&gt;%1&lt;/b&gt; does not work.&lt;br/&gt;Falling back to &lt;b&gt;%2&lt;/b&gt;.&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/audiooutput.cpp" line="388"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/audiooutput.cpp" line="388"/>
         <source>&lt;html&gt;Switching to the audio playback device &lt;b&gt;%1&lt;/b&gt;&lt;br/&gt;which just became available and has higher preference.&lt;/html&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/audiooutput.cpp" line="391"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/audiooutput.cpp" line="391"/>
         <source>Revert back to device &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -22,7 +22,7 @@
 <context>
     <name>CloseButton</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qtabbar.cpp" line="2259"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qtabbar.cpp" line="2259"/>
         <source>Close Tab</source>
         <translation type="unfinished"></translation>
     </message>
@@ -30,32 +30,32 @@
 <context>
     <name>Phonon::</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="55"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="55"/>
         <source>Notifications</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="57"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="57"/>
         <source>Music</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="59"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="59"/>
         <source>Video</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="61"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="61"/>
         <source>Communication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="63"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="63"/>
         <source>Games</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/phononnamespace.cpp" line="65"/>
         <source>Accessibility</source>
         <translation type="unfinished"></translation>
     </message>
@@ -63,13 +63,13 @@
 <context>
     <name>Phonon::Gstreamer::Backend</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/backend.cpp" line="171"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/backend.cpp" line="171"/>
         <source>Warning: You do not seem to have the package gstreamer0.10-plugins-good installed.
           Some video features have been disabled.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/backend.cpp" line="176"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/backend.cpp" line="176"/>
         <source>Warning: You do not seem to have the base GStreamer plugins installed.
           All audio and video support has been disabled</source>
         <translation type="unfinished"></translation>
@@ -78,7 +78,7 @@
 <context>
     <name>Phonon::Gstreamer::MediaObject</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="90"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="90"/>
         <source>Cannot start playback. 
 
 Check your Gstreamer installation and make sure you 
@@ -86,39 +86,39 @@ have libgstreamer-plugins-base installed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="203"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="203"/>
         <source>A required codec is missing. You need to install the following codec(s) to play this content: %0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="879"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="887"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="902"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="911"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="917"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="936"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1271"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1295"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="879"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="887"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="902"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="911"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="917"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="936"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1271"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1295"/>
         <source>Could not open media source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="892"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="892"/>
         <source>Invalid source type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1269"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1269"/>
         <source>Could not locate media source.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1279"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1279"/>
         <source>Could not open audio device. The device is already in use.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1292"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/gstreamer/mediaobject.cpp" line="1292"/>
         <source>Could not decode media source.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -126,15 +126,15 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>Phonon::VolumeSlider</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="42"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="60"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="42"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="60"/>
         <source>Volume: %1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="45"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="63"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="117"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="45"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="63"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="117"/>
         <source>Use this slider to adjust the volume. The leftmost position is 0%, the rightmost is %1%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -142,67 +142,67 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>Q3TitleBar</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="246"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="246"/>
         <source>System</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="249"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="249"/>
         <source>Restore up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="250"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="250"/>
         <source>Minimize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="253"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="253"/>
         <source>Restore down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="254"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="254"/>
         <source>Maximize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="256"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="256"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="274"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="274"/>
         <source>Contains commands to manipulate the window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="277"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="277"/>
         <source>Puts a minimized back to normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="278"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="278"/>
         <source>Moves the window out of the way</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="281"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="281"/>
         <source>Puts a maximized window back to normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="282"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="282"/>
         <source>Makes the window full screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="284"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="284"/>
         <source>Closes the window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="286"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/compat/q3complexwidgets.cpp" line="286"/>
         <source>Displays the name of the window and contains controls to manipulate it</source>
         <translation type="unfinished"></translation>
     </message>
@@ -210,44 +210,44 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QAbstractSocket</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="514"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="1301"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="1509"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="514"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="1301"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="1509"/>
         <source>Operation on socket is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="870"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="616"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="657"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="683"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="870"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="616"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="657"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="683"/>
         <source>Host not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="920"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="619"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="687"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="920"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="619"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="687"/>
         <source>Connection refused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="1061"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="1061"/>
         <source>Connection timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="1646"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="1646"/>
         <source>Socket operation timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="2026"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qabstractsocket.cpp" line="2026"/>
         <source>Socket is not connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="679"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="679"/>
         <source>Network unreachable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -255,17 +255,17 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QAbstractSpinBox</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qabstractspinbox.cpp" line="1193"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qabstractspinbox.cpp" line="1193"/>
         <source>&amp;Select All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qabstractspinbox.cpp" line="1199"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qabstractspinbox.cpp" line="1199"/>
         <source>&amp;Step up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qabstractspinbox.cpp" line="1201"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qabstractspinbox.cpp" line="1201"/>
         <source>Step &amp;down</source>
         <translation type="unfinished"></translation>
     </message>
@@ -273,27 +273,27 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QApplication</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/accessible/qaccessibleobject.cpp" line="376"/>
+        <location filename="../../qtopiacore/qt/src/gui/accessible/qaccessibleobject.cpp" line="376"/>
         <source>Activate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/accessible/qaccessibleobject.cpp" line="378"/>
+        <location filename="../../qtopiacore/qt/src/gui/accessible/qaccessibleobject.cpp" line="378"/>
         <source>Activates the program&apos;s main window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.h" line="352"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.h" line="352"/>
         <source>Executable &apos;%1&apos; requires Qt %2, found Qt %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.h" line="354"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.h" line="354"/>
         <source>Incompatible Qt Library Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qapplication.cpp" line="2247"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qapplication.cpp" line="2247"/>
         <source>QT_LAYOUT_DIRECTION</source>
         <comment>Translate this string to the string &apos;LTR&apos; in left-to-right languages or to &apos;RTL&apos; in right-to-left languages (such as Hebrew and Arabic) to get proper widget layout.</comment>
         <translation type="unfinished"></translation>
@@ -302,22 +302,22 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QAxSelect</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/activeqt/container/qaxselect.ui" line="55"/>
+        <location filename="../../qtopiacore/qt/src/activeqt/container/qaxselect.ui" line="55"/>
         <source>Select ActiveX Control</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/activeqt/container/qaxselect.ui" line="87"/>
+        <location filename="../../qtopiacore/qt/src/activeqt/container/qaxselect.ui" line="87"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/activeqt/container/qaxselect.ui" line="103"/>
+        <location filename="../../qtopiacore/qt/src/activeqt/container/qaxselect.ui" line="103"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/activeqt/container/qaxselect.ui" line="152"/>
+        <location filename="../../qtopiacore/qt/src/activeqt/container/qaxselect.ui" line="152"/>
         <source>COM &amp;Object:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -325,17 +325,17 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QCheckBox</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="114"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="114"/>
         <source>Uncheck</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="117"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="117"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="118"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="118"/>
         <source>Toggle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -343,57 +343,57 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QColorDialog</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1253"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1253"/>
         <source>Hu&amp;e:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1254"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1254"/>
         <source>&amp;Sat:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1255"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1255"/>
         <source>&amp;Val:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1256"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1256"/>
         <source>&amp;Red:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1257"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1257"/>
         <source>&amp;Green:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1258"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1258"/>
         <source>Bl&amp;ue:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1259"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1259"/>
         <source>A&amp;lpha channel:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1360"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1360"/>
         <source>Select Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1497"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1497"/>
         <source>&amp;Basic colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1498"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1498"/>
         <source>&amp;Custom colors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1499"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qcolordialog.cpp" line="1499"/>
         <source>&amp;Add to Custom Colors</source>
         <translation type="unfinished"></translation>
     </message>
@@ -401,23 +401,23 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QComboBox</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qitemeditorfactory.cpp" line="556"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qitemeditorfactory.cpp" line="556"/>
         <source>False</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qitemeditorfactory.cpp" line="557"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qitemeditorfactory.cpp" line="557"/>
         <source>True</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1771"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1836"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1771"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1836"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1836"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1836"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -425,19 +425,19 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="119"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="119"/>
         <source>%1: key is empty</source>
         <comment>QSystemSemaphore</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="131"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="131"/>
         <source>%1: unable to make key</source>
         <comment>QSystemSemaphore</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="140"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="140"/>
         <source>%1: ftok failed</source>
         <comment>QSystemSemaphore</comment>
         <translation type="unfinished"></translation>
@@ -446,22 +446,22 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDB2Driver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1262"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1262"/>
         <source>Unable to connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1525"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1525"/>
         <source>Unable to commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1542"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1542"/>
         <source>Unable to rollback transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1557"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1557"/>
         <source>Unable to set autocommit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -469,33 +469,33 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDB2Result</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="568"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="811"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="568"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="811"/>
         <source>Unable to execute statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="605"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="605"/>
         <source>Unable to prepare statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="801"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="801"/>
         <source>Unable to bind variable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="893"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="893"/>
         <source>Unable to fetch record %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="910"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="910"/>
         <source>Unable to fetch next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="930"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="930"/>
         <source>Unable to fetch first</source>
         <translation type="unfinished"></translation>
     </message>
@@ -503,22 +503,22 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDateTimeEdit</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdatetimeedit.cpp" line="2295"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdatetimeedit.cpp" line="2295"/>
         <source>AM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdatetimeedit.cpp" line="2295"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdatetimeedit.cpp" line="2295"/>
         <source>am</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdatetimeedit.cpp" line="2297"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdatetimeedit.cpp" line="2297"/>
         <source>PM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdatetimeedit.cpp" line="2297"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdatetimeedit.cpp" line="2297"/>
         <source>pm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -526,17 +526,17 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDial</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="951"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="951"/>
         <source>QDial</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="953"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="953"/>
         <source>SpeedoMeter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="955"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="955"/>
         <source>SliderHandle</source>
         <translation type="unfinished"></translation>
     </message>
@@ -544,12 +544,12 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDialog</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qdialog.cpp" line="482"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qdialog.cpp" line="482"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qdialog.cpp" line="597"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qdialog.cpp" line="597"/>
         <source>What&apos;s This?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -557,124 +557,124 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDialogButtonBox</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1866"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="2330"/>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="561"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1866"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="2330"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="561"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="561"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="561"/>
         <source>&amp;OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="564"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="564"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="564"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="564"/>
         <source>Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="567"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="567"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="570"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="570"/>
         <source>&amp;Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="570"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="570"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="573"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="573"/>
         <source>&amp;Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="573"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="573"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="576"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="576"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="579"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="579"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="582"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="582"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="586"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="586"/>
         <source>Don&apos;t Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="588"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="588"/>
         <source>Close without Saving</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="590"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="590"/>
         <source>Discard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="593"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="593"/>
         <source>&amp;Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="596"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="596"/>
         <source>Yes to &amp;All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="599"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="599"/>
         <source>&amp;No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="602"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="602"/>
         <source>N&amp;o to All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="605"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="605"/>
         <source>Save All</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="608"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="608"/>
         <source>Abort</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="611"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="611"/>
         <source>Retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="614"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="614"/>
         <source>Ignore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="617"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qdialogbuttonbox.cpp" line="617"/>
         <source>Restore Defaults</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,29 +682,29 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDirModel</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="456"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="456"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="457"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="457"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="460"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="460"/>
         <source>Kind</source>
         <comment>Match OS X Finder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="462"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="462"/>
         <source>Type</source>
         <comment>All other platforms</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="468"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="468"/>
         <source>Date Modified</source>
         <translation type="unfinished"></translation>
     </message>
@@ -712,17 +712,17 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDockWidget</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblewidgets.cpp" line="1239"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblewidgets.cpp" line="1239"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblewidgets.cpp" line="1241"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblewidgets.cpp" line="1241"/>
         <source>Dock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblewidgets.cpp" line="1242"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblewidgets.cpp" line="1242"/>
         <source>Float</source>
         <translation type="unfinished"></translation>
     </message>
@@ -730,12 +730,12 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QDoubleSpinBox</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="418"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="418"/>
         <source>More</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="420"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="420"/>
         <source>Less</source>
         <translation type="unfinished"></translation>
     </message>
@@ -743,27 +743,27 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QErrorMessage</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="192"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="192"/>
         <source>Debug Message:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="195"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="195"/>
         <source>Warning:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="198"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="198"/>
         <source>Fatal Error:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="391"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="391"/>
         <source>&amp;Show this message again</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="392"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qerrormessage.cpp" line="392"/>
         <source>&amp;OK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -771,38 +771,38 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QFile</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="708"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="858"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="708"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="858"/>
         <source>Destination file exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="722"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="722"/>
         <source>Will not rename sequential file using block copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="745"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="745"/>
         <source>Cannot remove source file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="870"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="870"/>
         <source>Cannot open %1 for input</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="887"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="887"/>
         <source>Cannot open for output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="897"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="897"/>
         <source>Failure to write block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="910"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qfile.cpp" line="910"/>
         <source>Cannot create %1 for output</source>
         <translation type="unfinished"></translation>
     </message>
@@ -810,211 +810,211 @@ have libgstreamer-plugins-base installed.</source>
 <context>
     <name>QFileDialog</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="495"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="495"/>
         <source>Find Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="497"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="497"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="499"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="499"/>
         <source>Save As</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="514"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="964"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="514"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="964"/>
         <source>All Files (*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="524"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="524"/>
         <source>Show </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="528"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="528"/>
         <source>&amp;Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="529"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="529"/>
         <source>&amp;Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="530"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="530"/>
         <source>Show &amp;hidden files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="531"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="531"/>
         <source>&amp;New Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="536"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1190"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="536"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1190"/>
         <source>Directory:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="538"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1196"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="538"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1196"/>
         <source>File &amp;name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1183"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1233"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2686"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2761"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1183"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1233"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2686"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2761"/>
         <source>&amp;Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1183"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1233"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1183"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1233"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1186"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1186"/>
         <source>Directories</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1193"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1231"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1193"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1231"/>
         <source>&amp;Choose</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1966"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2828"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="1966"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2828"/>
         <source>%1
 Directory not found.
 Please verify the correct directory name was given.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2000"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2000"/>
         <source>%1 already exists.
 Do you want to replace it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2020"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2020"/>
         <source>%1
 File not found.
 Please verify the correct file name was given.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2482"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2482"/>
         <source>New Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2610"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2610"/>
         <source>&apos;%1&apos; is write protected.
 Do you want to delete it anyway?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2615"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2615"/>
         <source>Are sure you want to delete &apos;%1&apos;?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2630"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="2630"/>
         <source>Could not delete directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="3037"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.cpp" line="3037"/>
         <source>Recent Places</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="59"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="290"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="59"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="290"/>
         <source>Look in:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="84"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="71"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="84"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="71"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="91"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="78"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="91"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="78"/>
         <source>Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="98"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="85"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="98"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="85"/>
         <source>Parent Directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="105"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="92"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="105"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="92"/>
         <source>Create New Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="112"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="99"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="112"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="99"/>
         <source>List View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="119"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="106"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="119"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="106"/>
         <source>Detail View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="260"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="268"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog.ui" line="260"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_wince.ui" line="268"/>
         <source>Files of type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfiledialog_win.cpp" line="160"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfiledialog_win.cpp" line="160"/>
         <source>All Files (*.*)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qsidebar.cpp" line="437"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qsidebar.cpp" line="437"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="870"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qdirmodel.cpp" line="870"/>
         <source>My Computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qfileiconprovider.cpp" line="446"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qfileiconprovider.cpp" line="446"/>
         <source>Drive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qfileiconprovider.cpp" line="449"/>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qfileiconprovider.cpp" line="450"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qfileiconprovider.cpp" line="449"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qfileiconprovider.cpp" line="450"/>
         <source>File</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/itemviews/qfileiconprovider.cpp" line="479"/>
+        <location filename="../../qtopiacore/qt/src/gui/itemviews/qfileiconprovider.cpp" line="479"/>
         <source>Unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1022,74 +1022,74 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QFileSystemModel</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="744"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="744"/>
         <source>%1 TB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="746"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="746"/>
         <source>%1 GB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="748"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="748"/>
         <source>%1 MB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="750"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="750"/>
         <source>%1 KB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="751"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="751"/>
         <source>%1 bytes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="828"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="828"/>
         <source>Invalid filename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="829"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="829"/>
         <source>&lt;b&gt;The name &quot;%1&quot; can not be used.&lt;/b&gt;&lt;p&gt;Try using another name, with fewer characters or no punctuations marks.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="893"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="893"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="895"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="895"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="899"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="899"/>
         <source>Kind</source>
         <comment>Match OS X Finder</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="901"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="901"/>
         <source>Type</source>
         <comment>All other platforms</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="908"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel.cpp" line="908"/>
         <source>Date Modified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel_p.h" line="249"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel_p.h" line="249"/>
         <source>My Computer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel_p.h" line="251"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfilesystemmodel_p.h" line="251"/>
         <source>Computer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1097,216 +1097,216 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QFontDatabase</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="90"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1266"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="90"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1266"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="93"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="105"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1254"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="93"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="105"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1254"/>
         <source>Bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="96"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1256"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="96"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1256"/>
         <source>Demi Bold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="99"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="117"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1252"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="99"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="117"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1252"/>
         <source>Black</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="107"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="107"/>
         <source>Demi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="113"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1258"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="113"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1258"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="254"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1261"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="254"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1261"/>
         <source>Italic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="257"/>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1263"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="257"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1263"/>
         <source>Oblique</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1968"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1968"/>
         <source>Any</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1971"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1971"/>
         <source>Latin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1974"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1974"/>
         <source>Greek</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1977"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1977"/>
         <source>Cyrillic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1980"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1980"/>
         <source>Armenian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1983"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1983"/>
         <source>Hebrew</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1986"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1986"/>
         <source>Arabic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1989"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1989"/>
         <source>Syriac</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1992"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1992"/>
         <source>Thaana</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1995"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1995"/>
         <source>Devanagari</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1998"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="1998"/>
         <source>Bengali</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2001"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2001"/>
         <source>Gurmukhi</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2004"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2004"/>
         <source>Gujarati</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2007"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2007"/>
         <source>Oriya</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2010"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2010"/>
         <source>Tamil</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2013"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2013"/>
         <source>Telugu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2016"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2016"/>
         <source>Kannada</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2019"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2019"/>
         <source>Malayalam</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2022"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2022"/>
         <source>Sinhala</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2025"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2025"/>
         <source>Thai</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2028"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2028"/>
         <source>Lao</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2031"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2031"/>
         <source>Tibetan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2034"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2034"/>
         <source>Myanmar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2037"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2037"/>
         <source>Georgian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2040"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2040"/>
         <source>Khmer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2043"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2043"/>
         <source>Simplified Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2046"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2046"/>
         <source>Traditional Chinese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2049"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2049"/>
         <source>Japanese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2052"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2052"/>
         <source>Korean</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2055"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2055"/>
         <source>Vietnamese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2058"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2058"/>
         <source>Symbol</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2061"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2061"/>
         <source>Ogham</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2064"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qfontdatabase.cpp" line="2064"/>
         <source>Runic</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1314,48 +1314,48 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QFontDialog</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="175"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="430"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="175"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="430"/>
         <source>Select Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="780"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="780"/>
         <source>&amp;Font</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="781"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="781"/>
         <source>Font st&amp;yle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="782"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="782"/>
         <source>&amp;Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="783"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="783"/>
         <source>Effects</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="784"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="784"/>
         <source>Stri&amp;keout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="785"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="785"/>
         <source>&amp;Underline</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="786"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="786"/>
         <source>Sample</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="787"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qfontdialog.cpp" line="787"/>
         <source>Wr&amp;iting System</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,97 +1363,97 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QFtp</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="826"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="826"/>
         <source>Not connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="891"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="891"/>
         <source>Host %1 not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="895"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="895"/>
         <source>Connection refused to host %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="899"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="899"/>
         <source>Connection timed out to host %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="1003"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="1003"/>
         <source>Connected to host %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="1222"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="1222"/>
         <source>Connection refused for data connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="1400"/>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="1429"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="1400"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="1429"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2318"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2318"/>
         <source>Connecting to host failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2322"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2322"/>
         <source>Login failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2326"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2326"/>
         <source>Listing directory failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2330"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2330"/>
         <source>Changing directory failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2334"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2334"/>
         <source>Downloading file failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2338"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2338"/>
         <source>Uploading file failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2342"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2342"/>
         <source>Removing file failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2346"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2346"/>
         <source>Creating directory failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2350"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2350"/>
         <source>Removing directory failed:
 %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qftp.cpp" line="2378"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qftp.cpp" line="2378"/>
         <source>Connection closed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1461,7 +1461,7 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QHostInfo</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_p.h" line="183"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_p.h" line="183"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1469,29 +1469,29 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QHostInfoAgent</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="178"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="187"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="251"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="282"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="165"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="174"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="214"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="241"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="178"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="187"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="251"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="282"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="165"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="174"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="214"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="241"/>
         <source>Host not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="238"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="277"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="207"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="236"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="238"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="277"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="207"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="236"/>
         <source>Unknown address type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="285"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="217"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="244"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_unix.cpp" line="285"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="217"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo_win.cpp" line="244"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1499,117 +1499,117 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QHttp</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="365"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="365"/>
         <source>HTTPS connection requested but SSL support not compiled in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="1573"/>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2393"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="1573"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2393"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="1825"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="1825"/>
         <source>Request aborted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2404"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2404"/>
         <source>No server set to connect to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2568"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2568"/>
         <source>Wrong content length</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2572"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2572"/>
         <source>Server closed connection unexpectedly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2627"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2627"/>
         <source>Connection refused (or timed out)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2630"/>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="905"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2630"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="905"/>
         <source>Host %1 not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2650"/>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="915"/>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="934"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2650"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="915"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="934"/>
         <source>HTTP request failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2723"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2723"/>
         <source>Invalid HTTP response header</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2751"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2751"/>
         <source>Unknown authentication method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2761"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2761"/>
         <source>Proxy authentication required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2765"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2765"/>
         <source>Authentication required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2848"/>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2896"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2848"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2896"/>
         <source>Invalid HTTP chunked body</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2934"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttp.cpp" line="2934"/>
         <source>Error writing response to device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="909"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="909"/>
         <source>Connection refused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="912"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="912"/>
         <source>Connection closed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="918"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="918"/>
         <source>Proxy requires authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="921"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="921"/>
         <source>Host requires authentication</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="924"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="924"/>
         <source>Data corrupted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="927"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="927"/>
         <source>Unknown protocol specified</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="930"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qhttpnetworkconnection.cpp" line="930"/>
         <source>SSL handshake failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1617,47 +1617,47 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QHttpSocketEngine</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="530"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="530"/>
         <source>Did not receive HTTP response from proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="555"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="555"/>
         <source>Error parsing authentication request from proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="586"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="586"/>
         <source>Authentication required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="613"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="613"/>
         <source>Proxy denied connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="623"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="623"/>
         <source>Error communicating with HTTP proxy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="646"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="646"/>
         <source>Proxy server not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="648"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="648"/>
         <source>Proxy connection refused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="650"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="650"/>
         <source>Proxy server connection timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="652"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qhttpsocketengine.cpp" line="652"/>
         <source>Proxy connection closed prematurely</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1665,22 +1665,22 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QIBaseDriver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1457"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1457"/>
         <source>Error opening database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1511"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1511"/>
         <source>Could not start transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1524"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1524"/>
         <source>Unable to commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1537"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1537"/>
         <source>Unable to rollback transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1688,89 +1688,89 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QIBaseResult</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="422"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="422"/>
         <source>Unable to create BLOB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="428"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="428"/>
         <source>Unable to write BLOB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="442"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="442"/>
         <source>Unable to open BLOB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="458"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="458"/>
         <source>Unable to read BLOB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="583"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="770"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="583"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="770"/>
         <source>Could not find array</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="615"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="615"/>
         <source>Could not get array data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="825"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="825"/>
         <source>Could not get query info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="845"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="845"/>
         <source>Could not start transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="864"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="864"/>
         <source>Unable to commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="906"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="906"/>
         <source>Could not allocate statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="911"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="911"/>
         <source>Could not prepare statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="916"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="927"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="916"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="927"/>
         <source>Could not describe input statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="941"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="941"/>
         <source>Could not describe statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1056"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1056"/>
         <source>Unable to close statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1064"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1064"/>
         <source>Unable to execute query</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1110"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1110"/>
         <source>Could not fetch next item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1273"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/ibase/qsql_ibase.cpp" line="1273"/>
         <source>Could not get statement info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1778,27 +1778,27 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QIODevice</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/global/qglobal.cpp" line="1894"/>
+        <location filename="../../qtopiacore/qt/src/corelib/global/qglobal.cpp" line="1894"/>
         <source>Permission denied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/global/qglobal.cpp" line="1897"/>
+        <location filename="../../qtopiacore/qt/src/corelib/global/qglobal.cpp" line="1897"/>
         <source>Too many open files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/global/qglobal.cpp" line="1900"/>
+        <location filename="../../qtopiacore/qt/src/corelib/global/qglobal.cpp" line="1900"/>
         <source>No such file or directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/global/qglobal.cpp" line="1903"/>
+        <location filename="../../qtopiacore/qt/src/corelib/global/qglobal.cpp" line="1903"/>
         <source>No space left on device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qiodevice.cpp" line="1537"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qiodevice.cpp" line="1537"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1806,22 +1806,22 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QInputContext</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/inputmethod/qinputcontextfactory.cpp" line="242"/>
+        <location filename="../../qtopiacore/qt/src/gui/inputmethod/qinputcontextfactory.cpp" line="242"/>
         <source>XIM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/inputmethod/qinputcontextfactory.cpp" line="265"/>
+        <location filename="../../qtopiacore/qt/src/gui/inputmethod/qinputcontextfactory.cpp" line="265"/>
         <source>XIM input method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/inputmethod/qinputcontextfactory.cpp" line="269"/>
+        <location filename="../../qtopiacore/qt/src/gui/inputmethod/qinputcontextfactory.cpp" line="269"/>
         <source>Windows input method</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/inputmethod/qinputcontextfactory.cpp" line="273"/>
+        <location filename="../../qtopiacore/qt/src/gui/inputmethod/qinputcontextfactory.cpp" line="273"/>
         <source>Mac OS X input method</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1829,7 +1829,7 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QInputDialog</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qinputdialog.cpp" line="223"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qinputdialog.cpp" line="223"/>
         <source>Enter a value:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1837,66 +1837,66 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QLibrary</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="378"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="378"/>
         <source>Could not mmap &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="400"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="400"/>
         <source>Plugin verification data mismatch in &apos;%1&apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="406"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="406"/>
         <source>Could not unmap &apos;%1&apos;: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="691"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qpluginloader.cpp" line="280"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="691"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qpluginloader.cpp" line="280"/>
         <source>The shared library was not found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="693"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="693"/>
         <source>The file &apos;%1&apos; is not a valid Qt plugin.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="708"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="708"/>
         <source>The plugin &apos;%1&apos; uses incompatible Qt library. (%2.%3.%4) [%5]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="728"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="728"/>
         <source>The plugin &apos;%1&apos; uses incompatible Qt library. Expected build key &quot;%2&quot;, got &quot;%3&quot;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="736"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="736"/>
         <source>The plugin &apos;%1&apos; uses incompatible Qt library. (Cannot mix debug and release libraries.)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="1068"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary.cpp" line="1068"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary_unix.cpp" line="209"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary_win.cpp" line="99"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary_unix.cpp" line="209"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary_win.cpp" line="99"/>
         <source>Cannot load library %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary_unix.cpp" line="225"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary_win.cpp" line="125"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary_unix.cpp" line="225"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary_win.cpp" line="125"/>
         <source>Cannot unload library %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary_unix.cpp" line="256"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qlibrary_win.cpp" line="140"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary_unix.cpp" line="256"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qlibrary_win.cpp" line="140"/>
         <source>Cannot resolve symbol &quot;%1&quot; in %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1904,37 +1904,37 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QLineEdit</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2680"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2680"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2684"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2684"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2691"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2691"/>
         <source>Cu&amp;t</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2695"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2695"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2699"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2699"/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2704"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2704"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2710"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qlineedit.cpp" line="2710"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1942,24 +1942,24 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QLocalServer</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalserver.cpp" line="226"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalserver_unix.cpp" line="233"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalserver.cpp" line="226"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalserver_unix.cpp" line="233"/>
         <source>%1: Name error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalserver_unix.cpp" line="225"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalserver_unix.cpp" line="225"/>
         <source>%1: Permission denied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalserver_unix.cpp" line="237"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalserver_unix.cpp" line="237"/>
         <source>%1: Address in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalserver_unix.cpp" line="242"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalserver_win.cpp" line="158"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalserver_unix.cpp" line="242"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalserver_win.cpp" line="158"/>
         <source>%1: Unknown error %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1967,70 +1967,70 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QLocalSocket</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="132"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="134"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="132"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="134"/>
         <source>%1: Connection refused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="135"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="137"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="135"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="137"/>
         <source>%1: Remote closed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="138"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="140"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_win.cpp" line="80"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_win.cpp" line="123"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="138"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="140"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_win.cpp" line="80"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_win.cpp" line="123"/>
         <source>%1: Invalid name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="141"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="143"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="141"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="143"/>
         <source>%1: Socket access error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="144"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="146"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="144"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="146"/>
         <source>%1: Socket resource error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="147"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="149"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="147"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="149"/>
         <source>%1: Socket operation timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="150"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="152"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="150"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="152"/>
         <source>%1: Datagram too large</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="153"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="155"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_win.cpp" line="75"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="153"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="155"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_win.cpp" line="75"/>
         <source>%1: Connection error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="156"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="158"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="156"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="158"/>
         <source>%1: The socket operation is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="160"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_tcp.cpp" line="160"/>
         <source>%1: Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="162"/>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qlocalsocket_win.cpp" line="85"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_unix.cpp" line="162"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qlocalsocket_win.cpp" line="85"/>
         <source>%1: Unknown error %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2038,27 +2038,27 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QMYSQLDriver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1251"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1251"/>
         <source>Unable to open database &apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1258"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1258"/>
         <source>Unable to connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1389"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1389"/>
         <source>Unable to begin transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1406"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1406"/>
         <source>Unable to commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1423"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1423"/>
         <source>Unable to rollback transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2066,59 +2066,59 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QMYSQLResult</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="485"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="485"/>
         <source>Unable to fetch data</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="668"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="668"/>
         <source>Unable to execute query</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="674"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="674"/>
         <source>Unable to store result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="776"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="776"/>
         <source>Unable to execute next query</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="786"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="786"/>
         <source>Unable to store next result</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="868"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="876"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="868"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="876"/>
         <source>Unable to prepare statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="912"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="912"/>
         <source>Unable to reset statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="998"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="998"/>
         <source>Unable to bind value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1009"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1009"/>
         <source>Unable to execute statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1023"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1044"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1023"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1044"/>
         <source>Unable to bind outvalues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1032"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/mysql/qsql_mysql.cpp" line="1032"/>
         <source>Unable to store statement results</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2126,7 +2126,7 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QMdiArea</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdiarea.cpp" line="290"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdiarea.cpp" line="290"/>
         <source>(Untitled)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2134,92 +2134,92 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QMdiSubWindow</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="279"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="279"/>
         <source>- [%1]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="280"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="280"/>
         <source>%1 - [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="334"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="334"/>
         <source>Minimize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="337"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="337"/>
         <source>Maximize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="340"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="340"/>
         <source>Unshade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="343"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="343"/>
         <source>Shade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="347"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="347"/>
         <source>Restore Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="349"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="349"/>
         <source>Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="352"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="352"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="355"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="355"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="358"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="358"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1054"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1054"/>
         <source>&amp;Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1057"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1057"/>
         <source>&amp;Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1058"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1058"/>
         <source>&amp;Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1059"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1059"/>
         <source>Mi&amp;nimize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1061"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1061"/>
         <source>Ma&amp;ximize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1063"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1063"/>
         <source>Stay on &amp;Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1066"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qmdisubwindow.cpp" line="1066"/>
         <source>&amp;Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2227,21 +2227,21 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QMenu</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="157"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="382"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="157"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="382"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="158"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="383"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="158"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="383"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="160"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="385"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="436"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="160"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="385"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/qaccessiblemenu.cpp" line="436"/>
         <source>Execute</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2249,35 +2249,35 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QMessageBox</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="122"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="122"/>
         <source>Show Details...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="123"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="123"/>
         <source>Hide Details...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="369"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1216"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.h" line="302"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.h" line="310"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="369"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1216"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.h" line="302"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.h" line="310"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1217"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1217"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1693"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1693"/>
         <source>&lt;h3&gt;About Qt&lt;/h3&gt;&lt;p&gt;This program uses Qt version %1.&lt;/p&gt;&lt;p&gt;Qt is a C++ toolkit for cross-platform application development.&lt;/p&gt;&lt;p&gt;Qt provides single-source portability across MS&amp;nbsp;Windows, Mac&amp;nbsp;OS&amp;nbsp;X, Linux, and all major commercial Unix variants. Qt is also available for embedded devices as Qt for Embedded Linux and Qt for Windows CE.&lt;/p&gt;&lt;p&gt;Qt is available under three different licensing options designed to accommodate the needs of our various users.&lt;/p&gt;Qt licensed under our commercial license agreement is appropriate for development of proprietary/commercial software where you do not want to share any source code with third parties or otherwise cannot comply with the terms of the GNU LGPL version 2.1 or GNU GPL version 3.0.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU LGPL version 2.1 is appropriate for the development of Qt applications (proprietary or open source) provided you can comply with the terms and conditions of the GNU LGPL version 2.1.&lt;/p&gt;&lt;p&gt;Qt licensed under the GNU General Public License version 3.0 is appropriate for the development of Qt applications where you wish to use such applications in combination with software subject to the terms of the GNU GPL version 3.0 or where you are otherwise willing to comply with the terms of the GNU GPL version 3.0.&lt;/p&gt;&lt;p&gt;Please see &lt;a href=&quot;http://qt.nokia.com/products/licensing&quot;&gt;qt.nokia.com/products/licensing&lt;/a&gt; for an overview of Qt licensing.&lt;/p&gt;&lt;p&gt;Copyright (C) 2009 Nokia Corporation and/or its subsidiary(-ies).&lt;/p&gt;&lt;p&gt;Qt is a Nokia product. See &lt;a href=&quot;http://qt.nokia.com/&quot;&gt;qt.nokia.com&lt;/a&gt; for more information.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1727"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qmessagebox.cpp" line="1727"/>
         <source>About Qt</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2285,7 +2285,7 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QMultiInputContext</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/inputmethods/imsw-multi/qmultiinputcontext.cpp" line="88"/>
+        <location filename="../../qtopiacore/qt/src/plugins/inputmethods/imsw-multi/qmultiinputcontext.cpp" line="88"/>
         <source>Select IM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2293,12 +2293,12 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QMultiInputContextPlugin</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/inputmethods/imsw-multi/qmultiinputcontextplugin.cpp" line="95"/>
+        <location filename="../../qtopiacore/qt/src/plugins/inputmethods/imsw-multi/qmultiinputcontextplugin.cpp" line="95"/>
         <source>Multiple input method switcher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/inputmethods/imsw-multi/qmultiinputcontextplugin.cpp" line="102"/>
+        <location filename="../../qtopiacore/qt/src/plugins/inputmethods/imsw-multi/qmultiinputcontextplugin.cpp" line="102"/>
         <source>Multiple input method switcher that uses the context menu of the text widgets</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2306,132 +2306,132 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QNativeSocketEngine</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="197"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="197"/>
         <source>Unable to initialize non-blocking socket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="200"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="200"/>
         <source>Unable to initialize broadcast socket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="203"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="203"/>
         <source>Attempt to use IPv6 socket on a platform with no IPv6 support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="206"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="206"/>
         <source>The remote host closed the connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="209"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="209"/>
         <source>Network operation timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="212"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="212"/>
         <source>Out of resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="215"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="215"/>
         <source>Unsupported socket operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="218"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="218"/>
         <source>Protocol type not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="221"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="221"/>
         <source>Invalid socket descriptor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="224"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="224"/>
         <source>Host unreachable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="227"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="227"/>
         <source>Network unreachable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="230"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="230"/>
         <source>Permission denied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="233"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="233"/>
         <source>Connection timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="236"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="236"/>
         <source>Connection refused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="239"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="239"/>
         <source>The bound address is already in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="242"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="242"/>
         <source>The address is not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="245"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="245"/>
         <source>The address is protected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="248"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="248"/>
         <source>Datagram was too large to send</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="251"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="251"/>
         <source>Unable to send a message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="254"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="254"/>
         <source>Unable to receive a message</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="257"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="257"/>
         <source>Unable to write</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="260"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="260"/>
         <source>Network error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="263"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="263"/>
         <source>Another socket is already listening on the same port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="266"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="266"/>
         <source>Operation on non-socket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="269"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="269"/>
         <source>The proxy type is invalid for this operation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="272"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qnativesocketengine.cpp" line="272"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2439,7 +2439,7 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QNetworkAccessCacheBackend</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccesscachebackend.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccesscachebackend.cpp" line="65"/>
         <source>Error opening %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2447,27 +2447,27 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QNetworkAccessFileBackend</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="99"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="99"/>
         <source>Request for opening non-local file %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="141"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="141"/>
         <source>Error opening %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="197"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="197"/>
         <source>Write error writing to %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="230"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="230"/>
         <source>Cannot open %1: Path is a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="251"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessfilebackend.cpp" line="251"/>
         <source>Read error reading from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2475,27 +2475,27 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QNetworkAccessFtpBackend</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="165"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="165"/>
         <source>No suitable proxy found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="179"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="179"/>
         <source>Cannot open %1: is a directory</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="309"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="309"/>
         <source>Logging in to %1 failed: authentication required</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="348"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="348"/>
         <source>Error while downloading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="350"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessftpbackend.cpp" line="350"/>
         <source>Error while uploading %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2503,7 +2503,7 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QNetworkAccessHttpBackend</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccesshttpbackend.cpp" line="597"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccesshttpbackend.cpp" line="597"/>
         <source>No suitable proxy found</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2511,12 +2511,12 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QNetworkReply</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccesshttpbackend.cpp" line="729"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccesshttpbackend.cpp" line="729"/>
         <source>Error downloading %1 - server replied: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkreplyimpl.cpp" line="71"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkreplyimpl.cpp" line="71"/>
         <source>Protocol &quot;%1&quot; is unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2524,8 +2524,8 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QNetworkReplyImpl</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkreplyimpl.cpp" line="552"/>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkreplyimpl.cpp" line="580"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkreplyimpl.cpp" line="552"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkreplyimpl.cpp" line="580"/>
         <source>Operation canceled</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2533,28 +2533,28 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QOCIDriver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1938"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1938"/>
         <source>Unable to initialize</source>
         <comment>QOCIDriver</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="2082"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="2082"/>
         <source>Unable to logon</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="2153"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="2153"/>
         <source>Unable to begin transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="2172"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="2172"/>
         <source>Unable to commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="2191"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="2191"/>
         <source>Unable to rollback transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2562,44 +2562,44 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QOCIResult</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1215"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1376"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1391"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1215"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1376"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1391"/>
         <source>Unable to bind column for batch execute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1406"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1406"/>
         <source>Unable to execute batch statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1711"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1711"/>
         <source>Unable to goto next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1770"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1770"/>
         <source>Unable to alloc statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1785"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1785"/>
         <source>Unable to prepare statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1811"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1811"/>
         <source>Unable to get statement type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1831"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1831"/>
         <source>Unable to bind value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1850"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/oci/qsql_oci.cpp" line="1850"/>
         <source>Unable to execute statement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2607,32 +2607,32 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QODBCDriver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1694"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1694"/>
         <source>Unable to connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1700"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1700"/>
         <source>Unable to connect - Driver doesn&apos;t support all needed functionality</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1939"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1939"/>
         <source>Unable to disable autocommit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1956"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1956"/>
         <source>Unable to commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1973"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1973"/>
         <source>Unable to rollback transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1988"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1988"/>
         <source>Unable to enable autocommit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2640,51 +2640,51 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QODBCResult</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1124"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="927"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1511"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/db2/qsql_db2.cpp" line="1124"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="927"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1511"/>
         <source>Unable to fetch last</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="762"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1116"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="762"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1116"/>
         <source>QODBCResult::reset: Unable to set &apos;SQL_CURSOR_STATIC&apos; as statement attribute. Please check your ODBC driver configuration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="779"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1410"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="779"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1410"/>
         <source>Unable to execute statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="833"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="833"/>
         <source>Unable to fetch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="855"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="855"/>
         <source>Unable to fetch next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="877"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="877"/>
         <source>Unable to fetch first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="896"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="896"/>
         <source>Unable to fetch previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1134"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1134"/>
         <source>Unable to prepare statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1402"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/odbc/qsql_odbc.cpp" line="1402"/>
         <source>Unable to bind variable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2692,318 +2692,318 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/util/qdesktopservices_mac.cpp" line="165"/>
+        <location filename="../../qtopiacore/qt/src/gui/util/qdesktopservices_mac.cpp" line="165"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessdatabackend.cpp" line="74"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessdatabackend.cpp" line="74"/>
         <source>Operation not supported on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessdatabackend.cpp" line="127"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessdatabackend.cpp" line="127"/>
         <source>Invalid URI: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="175"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="175"/>
         <source>Write error writing to %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="232"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="232"/>
         <source>Read error reading from %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="263"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="263"/>
         <source>Socket error on %1: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="278"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="278"/>
         <source>Remote host closed the connection prematurely on %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="331"/>
+        <location filename="../../qtopiacore/qt/src/network/access/qnetworkaccessdebugpipebackend.cpp" line="331"/>
         <source>Protocol error: packet of size 0 received</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo.cpp" line="177"/>
-        <location filename="../../../qtopiacore/qt/src/network/kernel/qhostinfo.cpp" line="234"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo.cpp" line="177"/>
+        <location filename="../../qtopiacore/qt/src/network/kernel/qhostinfo.cpp" line="234"/>
         <source>No host name given</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="454"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="454"/>
         <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="456"/>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerstackmodel.cpp" line="161"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="456"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerstackmodel.cpp" line="161"/>
         <source>Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="458"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="458"/>
         <source>Condition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="460"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="460"/>
         <source>Ignore-count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="462"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="462"/>
         <source>Single-shot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="464"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointsmodel.cpp" line="464"/>
         <source>Hit-count</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointswidget.cpp" line="81"/>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="141"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointswidget.cpp" line="81"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="141"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointswidget.cpp" line="298"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointswidget.cpp" line="298"/>
         <source>New</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointswidget.cpp" line="304"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptbreakpointswidget.cpp" line="304"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="880"/>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1777"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="880"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1777"/>
         <source>Go to Line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="881"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="881"/>
         <source>Line:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1556"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1556"/>
         <source>Interrupt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1558"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1558"/>
         <source>Shift+F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1573"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1573"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1575"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1575"/>
         <source>F5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1590"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1590"/>
         <source>Step Into</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1592"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1592"/>
         <source>F11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1607"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1607"/>
         <source>Step Over</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1609"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1609"/>
         <source>F10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1624"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1624"/>
         <source>Step Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1626"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1626"/>
         <source>Shift+F11</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1641"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1641"/>
         <source>Run to Cursor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1643"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1643"/>
         <source>Ctrl+F10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1659"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1659"/>
         <source>Run to New Script</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1674"/>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptedit.cpp" line="401"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1674"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptedit.cpp" line="401"/>
         <source>Toggle Breakpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1675"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1675"/>
         <source>F9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1689"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1689"/>
         <source>Clear Debug Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1702"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1702"/>
         <source>Clear Error Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1715"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1715"/>
         <source>Clear Console</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1729"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1729"/>
         <source>&amp;Find in Script...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1730"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1730"/>
         <source>Ctrl+F</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1747"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1747"/>
         <source>Find &amp;Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1749"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1749"/>
         <source>F3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1762"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1762"/>
         <source>Find &amp;Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1764"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1764"/>
         <source>Shift+F3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1778"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebugger.cpp" line="1778"/>
         <source>Ctrl+G</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerlocalsmodel.cpp" line="869"/>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerstackmodel.cpp" line="159"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerlocalsmodel.cpp" line="869"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerstackmodel.cpp" line="159"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerlocalsmodel.cpp" line="871"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerlocalsmodel.cpp" line="871"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerstackmodel.cpp" line="157"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggerstackmodel.cpp" line="157"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptedit.cpp" line="403"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptedit.cpp" line="403"/>
         <source>Disable Breakpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptedit.cpp" line="404"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptedit.cpp" line="404"/>
         <source>Enable Breakpoint</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptedit.cpp" line="408"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptedit.cpp" line="408"/>
         <source>Breakpoint Condition:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="633"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="633"/>
         <source>Loaded Scripts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="639"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="639"/>
         <source>Breakpoints</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="645"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="645"/>
         <source>Stack</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="651"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="651"/>
         <source>Locals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="657"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="657"/>
         <source>Console</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="663"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="663"/>
         <source>Debug Output</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="669"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="669"/>
         <source>Error Log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="681"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="681"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="688"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="688"/>
         <source>View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="706"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="706"/>
         <source>Qt Script Debugger</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="734"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptenginedebugger.cpp" line="734"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3011,12 +3011,12 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QPPDOptionsModel</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="1197"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="1197"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="1199"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="1199"/>
         <source>Value</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3024,32 +3024,32 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QPSQLDriver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="785"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="785"/>
         <source>Unable to connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="834"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="834"/>
         <source>Could not begin transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="864"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="864"/>
         <source>Could not commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="880"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="880"/>
         <source>Could not rollback transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="1234"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="1234"/>
         <source>Unable to subscribe</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="1266"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="1266"/>
         <source>Unable to unsubscribe</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3057,12 +3057,12 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QPSQLResult</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="199"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="199"/>
         <source>Unable to create query</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="573"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/psql/qsql_psql.cpp" line="573"/>
         <source>Unable to prepare statement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3070,106 +3070,106 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QPageSetupWidget</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="304"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="304"/>
         <source>Centimeters (cm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="304"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="304"/>
         <source>Millimeters (mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="304"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="304"/>
         <source>Inches (in)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="304"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="304"/>
         <source>Points (pt)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="13"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="13"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="42"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="42"/>
         <source>Paper</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="48"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="48"/>
         <source>Page size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="61"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="61"/>
         <source>Width:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="80"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="80"/>
         <source>Height:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="99"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="99"/>
         <source>Paper source:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="128"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="128"/>
         <source>Orientation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="134"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="134"/>
         <source>Portrait</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="144"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="144"/>
         <source>Landscape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="151"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="151"/>
         <source>Reverse landscape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="158"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="158"/>
         <source>Reverse portrait</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="184"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="184"/>
         <source>Margins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="192"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="195"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="192"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="195"/>
         <source>top margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="223"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="226"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="223"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="226"/>
         <source>left margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="255"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="258"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="255"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="258"/>
         <source>right margin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="286"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="289"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="286"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupwidget.ui" line="289"/>
         <source>bottom margin</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3177,12 +3177,12 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QPluginLoader</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qpluginloader.cpp" line="236"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qpluginloader.cpp" line="236"/>
         <source>The plugin was not loaded.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/plugin/qpluginloader.cpp" line="304"/>
+        <location filename="../../qtopiacore/qt/src/corelib/plugin/qpluginloader.cpp" line="304"/>
         <source>Unknown error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3190,425 +3190,425 @@ Do you want to delete it anyway?</source>
 <context>
     <name>QPrintDialog</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qabstractprintdialog.cpp" line="110"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qabstractprintdialog.cpp" line="123"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_win.cpp" line="266"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qabstractprintdialog.cpp" line="110"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qabstractprintdialog.cpp" line="123"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_win.cpp" line="266"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="72"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="72"/>
         <source>A0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="73"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="73"/>
         <source>A1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="74"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="74"/>
         <source>A2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="75"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="75"/>
         <source>A3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="76"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="76"/>
         <source>A4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="77"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="77"/>
         <source>A5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="78"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="78"/>
         <source>A6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="79"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="79"/>
         <source>A7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="80"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="80"/>
         <source>A8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="81"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="81"/>
         <source>A9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="82"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="82"/>
         <source>B0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="83"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="83"/>
         <source>B1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="84"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="84"/>
         <source>B2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="85"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="85"/>
         <source>B3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="86"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="86"/>
         <source>B4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="87"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="87"/>
         <source>B5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="88"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="88"/>
         <source>B6</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="89"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="89"/>
         <source>B7</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="90"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="90"/>
         <source>B8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="91"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="91"/>
         <source>B9</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="92"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="92"/>
         <source>B10</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="93"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="93"/>
         <source>C5E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="94"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="94"/>
         <source>DLE</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="95"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="95"/>
         <source>Executive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="96"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="96"/>
         <source>Folio</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="97"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="97"/>
         <source>Ledger</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="98"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="98"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="99"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="99"/>
         <source>Letter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="100"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="100"/>
         <source>Tabloid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="101"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="101"/>
         <source>US Common #10 Envelope</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="102"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qpagesetupdialog_unix.cpp" line="102"/>
         <source>Custom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="148"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="148"/>
         <source>File exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="149"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="149"/>
         <source>&lt;qt&gt;Do you want to overwrite it?&lt;/qt&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="329"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="329"/>
         <source>A0 (841 x 1189 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="330"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="330"/>
         <source>A1 (594 x 841 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="331"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="331"/>
         <source>A2 (420 x 594 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="332"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="332"/>
         <source>A3 (297 x 420 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="333"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="333"/>
         <source>A4 (210 x 297 mm, 8.26 x 11.7 inches)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="334"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="334"/>
         <source>A5 (148 x 210 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="335"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="335"/>
         <source>A6 (105 x 148 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="336"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="336"/>
         <source>A7 (74 x 105 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="337"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="337"/>
         <source>A8 (52 x 74 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="338"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="338"/>
         <source>A9 (37 x 52 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="339"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="339"/>
         <source>B0 (1000 x 1414 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="340"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="340"/>
         <source>B1 (707 x 1000 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="341"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="341"/>
         <source>B2 (500 x 707 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="342"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="342"/>
         <source>B3 (353 x 500 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="343"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="343"/>
         <source>B4 (250 x 353 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="344"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="344"/>
         <source>B5 (176 x 250 mm, 6.93 x 9.84 inches)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="345"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="345"/>
         <source>B6 (125 x 176 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="346"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="346"/>
         <source>B7 (88 x 125 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="347"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="347"/>
         <source>B8 (62 x 88 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="348"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="348"/>
         <source>B9 (44 x 62 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="349"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="349"/>
         <source>B10 (31 x 44 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="350"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="350"/>
         <source>C5E (163 x 229 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="351"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="351"/>
         <source>DLE (110 x 220 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="352"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="352"/>
         <source>Executive (7.5 x 10 inches, 191 x 254 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="353"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="353"/>
         <source>Folio (210 x 330 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="354"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="354"/>
         <source>Ledger (432 x 279 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="355"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="355"/>
         <source>Legal (8.5 x 14 inches, 216 x 356 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="356"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="356"/>
         <source>Letter (8.5 x 11 inches, 216 x 279 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="357"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="357"/>
         <source>Tabloid (279 x 432 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="358"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="358"/>
         <source>US Common #10 Envelope (105 x 241 mm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="375"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="375"/>
         <source>Print all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="376"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="376"/>
         <source>Print selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="377"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_qws.cpp" line="377"/>
         <source>Print range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="394"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="462"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="394"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="462"/>
         <source>&amp;Options &gt;&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="399"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="399"/>
         <source>&amp;Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="466"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="466"/>
         <source>&amp;Options &lt;&lt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="719"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="719"/>
         <source>Print to File (PDF)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="720"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="720"/>
         <source>Print to File (Postscript)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="767"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="767"/>
         <source>Local file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="768"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="768"/>
         <source>Write %1 file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="842"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="842"/>
         <source>Print To File ...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="918"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="918"/>
         <source>%1 is a directory.
 Please choose a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="922"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="922"/>
         <source>File %1 is not writable.
 Please choose a different file name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="926"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_unix.cpp" line="926"/>
         <source>%1 already exists.
 Do you want to overwrite it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_win.cpp" line="267"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_win.cpp" line="267"/>
         <source>The &apos;From&apos; value cannot be greater than the &apos;To&apos; value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintdialog_win.cpp" line="268"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintdialog_win.cpp" line="268"/>
         <source>OK</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="98"/>
+        <location filename="../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="98"/>
         <source>locally connected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="121"/>
-        <location filename="../../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="346"/>
+        <location filename="../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="121"/>
+        <location filename="../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="346"/>
         <source>Aliases: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="569"/>
-        <location filename="../../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="768"/>
+        <location filename="../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="569"/>
+        <location filename="../../qtopiacore/qt/src/gui/painting/qprinterinfo_unix.cpp" line="768"/>
         <source>unknown</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3616,108 +3616,108 @@ Do you want to overwrite it?</source>
 <context>
     <name>QPrintPreviewDialog</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qabstractpagesetupdialog.cpp" line="68"/>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qabstractpagesetupdialog.cpp" line="80"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qabstractpagesetupdialog.cpp" line="68"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qabstractpagesetupdialog.cpp" line="80"/>
         <source>Page Setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="252"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="252"/>
         <source>%1%</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="331"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="331"/>
         <source>Print Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="360"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="360"/>
         <source>Next page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="361"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="361"/>
         <source>Previous page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="362"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="362"/>
         <source>First page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="363"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="363"/>
         <source>Last page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="372"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="372"/>
         <source>Fit width</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="373"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="373"/>
         <source>Fit page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="384"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="384"/>
         <source>Zoom in</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="385"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="385"/>
         <source>Zoom out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="391"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="391"/>
         <source>Portrait</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="392"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="392"/>
         <source>Landscape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="402"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="402"/>
         <source>Show single page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="403"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="403"/>
         <source>Show facing pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="404"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="404"/>
         <source>Show overview of all pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="419"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="419"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="420"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="420"/>
         <source>Page setup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="421"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="421"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="572"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="572"/>
         <source>Export to PDF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="575"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpreviewdialog.cpp" line="575"/>
         <source>Export to PostScript</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3725,17 +3725,17 @@ Do you want to overwrite it?</source>
 <context>
     <name>QPrintPropertiesWidget</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpropertieswidget.ui" line="13"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpropertieswidget.ui" line="13"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpropertieswidget.ui" line="34"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpropertieswidget.ui" line="34"/>
         <source>Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintpropertieswidget.ui" line="44"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintpropertieswidget.ui" line="44"/>
         <source>Advanced</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3743,97 +3743,97 @@ Do you want to overwrite it?</source>
 <context>
     <name>QPrintSettingsOutput</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="13"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="13"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="34"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="34"/>
         <source>Copies</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="46"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="46"/>
         <source>Print range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="58"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="58"/>
         <source>Print all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="76"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="76"/>
         <source>Pages from</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="96"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="96"/>
         <source>to</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="131"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="131"/>
         <source>Selection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="154"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="154"/>
         <source>Output Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="160"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="160"/>
         <source>Copies:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="193"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="193"/>
         <source>Collate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="210"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="210"/>
         <source>Reverse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="242"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="242"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="248"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="248"/>
         <source>Color Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="267"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="267"/>
         <source>Color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="277"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="277"/>
         <source>Grayscale</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="287"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="287"/>
         <source>Duplex Printing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="293"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="293"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="303"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="303"/>
         <source>Long side</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="310"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintsettingsoutput.ui" line="310"/>
         <source>Short side</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3841,47 +3841,47 @@ Do you want to overwrite it?</source>
 <context>
     <name>QPrintWidget</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="13"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="13"/>
         <source>Form</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="22"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="22"/>
         <source>Printer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="28"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="28"/>
         <source>&amp;Name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="54"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="54"/>
         <source>P&amp;roperties</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="61"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="61"/>
         <source>Location:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="71"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="71"/>
         <source>Preview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="78"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="78"/>
         <source>Type:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="88"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="88"/>
         <source>Output &amp;file:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="103"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprintwidget.ui" line="103"/>
         <source>...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3889,62 +3889,62 @@ Do you want to overwrite it?</source>
 <context>
     <name>QProcess</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="533"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="585"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="615"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="665"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="533"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="585"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="615"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="665"/>
         <source>Error reading from process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="632"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="1411"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="805"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="632"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="1411"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="805"/>
         <source>Error writing to process</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="702"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="702"/>
         <source>Process crashed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="1614"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess.cpp" line="1614"/>
         <source>No program defined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="466"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="147"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="466"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="147"/>
         <source>Could not open input redirection for reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="478"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="183"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="478"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="183"/>
         <source>Could not open output redirection for writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="713"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="713"/>
         <source>Resource error (fork failure): %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="972"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="1025"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="1099"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="1166"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="605"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="655"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="730"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="772"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="826"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="972"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="1025"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="1099"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_unix.cpp" line="1166"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="605"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="655"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="730"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="772"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="826"/>
         <source>Process operation timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="464"/>
+        <location filename="../../qtopiacore/qt/src/corelib/io/qprocess_win.cpp" line="464"/>
         <source>Process failed to start</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3952,7 +3952,7 @@ Do you want to overwrite it?</source>
 <context>
     <name>QProgressDialog</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qprogressdialog.cpp" line="182"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qprogressdialog.cpp" line="182"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3960,7 +3960,7 @@ Do you want to overwrite it?</source>
 <context>
     <name>QPushButton</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="110"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="110"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3968,7 +3968,7 @@ Do you want to overwrite it?</source>
 <context>
     <name>QRadioButton</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="122"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="122"/>
         <source>Check</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3976,47 +3976,47 @@ Do you want to overwrite it?</source>
 <context>
     <name>QRegExp</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="64"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="64"/>
         <source>no error occurred</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="65"/>
         <source>disabled feature used</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="66"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="66"/>
         <source>bad char class syntax</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="67"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="67"/>
         <source>bad lookahead syntax</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="68"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="68"/>
         <source>bad repetition syntax</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="69"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="69"/>
         <source>invalid octal value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="70"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="70"/>
         <source>missing left delim</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="71"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="71"/>
         <source>unexpected end</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="72"/>
+        <location filename="../../qtopiacore/qt/src/corelib/tools/qregexp.cpp" line="72"/>
         <source>met internal limit</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4024,22 +4024,22 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSQLite2Driver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="388"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="388"/>
         <source>Error to open database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="429"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="429"/>
         <source>Unable to begin transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="446"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="446"/>
         <source>Unable to commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="463"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="463"/>
         <source>Unable to rollback Transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4047,12 +4047,12 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSQLite2Result</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="148"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="148"/>
         <source>Unable to fetch results</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="287"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite2/qsql_sqlite2.cpp" line="287"/>
         <source>Unable to execute statement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4060,27 +4060,27 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSQLiteDriver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="539"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="539"/>
         <source>Error opening database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="550"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="550"/>
         <source>Error closing database</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="570"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="570"/>
         <source>Unable to begin transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="585"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="585"/>
         <source>Unable to commit transaction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="600"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="600"/>
         <source>Unable to rollback transaction</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4088,34 +4088,34 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSQLiteResult</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="200"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="266"/>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="274"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="200"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="266"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="274"/>
         <source>Unable to fetch row</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="201"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="201"/>
         <source>No query</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="337"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="337"/>
         <source>Unable to execute statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="357"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="357"/>
         <source>Unable to reset statement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="402"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="402"/>
         <source>Unable to bind parameters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="409"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/sqlite/qsql_sqlite.cpp" line="409"/>
         <source>Parameter count mismatch</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4123,27 +4123,27 @@ Do you want to overwrite it?</source>
 <context>
     <name>QScriptDebuggerCodeFinderWidget</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="154"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="154"/>
         <source>Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="161"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="161"/>
         <source>Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="166"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="166"/>
         <source>Case Sensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="169"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="169"/>
         <source>Whole words</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="178"/>
+        <location filename="../../qtopiacore/qt/src/scripttools/debugging/qscriptdebuggercodefinderwidget.cpp" line="178"/>
         <source>&lt;img src=&quot;:/qt/scripttools/debugging/images/wrap.png&quot;&gt;&amp;nbsp;Search wrapped</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4151,84 +4151,84 @@ Do you want to overwrite it?</source>
 <context>
     <name>QScrollBar</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="448"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="448"/>
         <source>Scroll here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="450"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="450"/>
         <source>Left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="450"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="450"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="451"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="451"/>
         <source>Right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="451"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="451"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="453"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="453"/>
         <source>Page left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="453"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="563"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="453"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="563"/>
         <source>Page up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="454"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="454"/>
         <source>Page right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="454"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="567"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="454"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="567"/>
         <source>Page down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="456"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="456"/>
         <source>Scroll left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="456"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="456"/>
         <source>Scroll up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="457"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="457"/>
         <source>Scroll right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="457"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qscrollbar.cpp" line="457"/>
         <source>Scroll down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="561"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="561"/>
         <source>Line up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="565"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="565"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="569"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="569"/>
         <source>Line down</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4236,99 +4236,99 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSharedMemory</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory.cpp" line="211"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory.cpp" line="211"/>
         <source>%1: unable to set key on lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory.cpp" line="292"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory.cpp" line="292"/>
         <source>%1: create size is less then 0</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory.cpp" line="460"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_p.h" line="148"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory.cpp" line="460"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_p.h" line="148"/>
         <source>%1: unable to lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory.cpp" line="482"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory.cpp" line="482"/>
         <source>%1: unable to unlock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="78"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="87"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="78"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="87"/>
         <source>%1: permission denied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="82"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="82"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="65"/>
         <source>%1: already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="86"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="74"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="86"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="74"/>
         <source>%1: doesn&apos;t exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="92"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="83"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="92"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="83"/>
         <source>%1: out of resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="96"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="90"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="96"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="90"/>
         <source>%1: unknown error %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="117"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="117"/>
         <source>%1: key is empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="125"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="125"/>
         <source>%1: unix key file doesn&apos;t exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="132"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="132"/>
         <source>%1: ftok failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="183"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="105"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="183"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="105"/>
         <source>%1: unable to make key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="203"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="203"/>
         <source>%1: system-imposed size restrictions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="256"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_unix.cpp" line="256"/>
         <source>%1: not attached</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="78"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="78"/>
         <source>%1: invalid size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="146"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="146"/>
         <source>%1: key error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="184"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsharedmemory_win.cpp" line="184"/>
         <source>%1: size query failed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4336,466 +4336,466 @@ Do you want to overwrite it?</source>
 <context>
     <name>QShortcut</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="373"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="373"/>
         <source>Space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="374"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="374"/>
         <source>Esc</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="375"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="375"/>
         <source>Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="376"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="376"/>
         <source>Backtab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="377"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="377"/>
         <source>Backspace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="378"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="378"/>
         <source>Return</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="379"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="379"/>
         <source>Enter</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="380"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="380"/>
         <source>Ins</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="381"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="381"/>
         <source>Del</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="382"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="382"/>
         <source>Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="383"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="383"/>
         <source>Print</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="384"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="384"/>
         <source>SysReq</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="385"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="385"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="386"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="386"/>
         <source>End</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="387"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="387"/>
         <source>Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="388"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="388"/>
         <source>Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="389"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="389"/>
         <source>Right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="390"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="390"/>
         <source>Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="391"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="391"/>
         <source>PgUp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="392"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="392"/>
         <source>PgDown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="393"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="393"/>
         <source>CapsLock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="394"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="394"/>
         <source>NumLock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="395"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="395"/>
         <source>ScrollLock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="396"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="396"/>
         <source>Menu</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="397"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="397"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="400"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="400"/>
         <source>Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="401"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="401"/>
         <source>Forward</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="402"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="402"/>
         <source>Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="403"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="403"/>
         <source>Refresh</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="404"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="404"/>
         <source>Volume Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="405"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="405"/>
         <source>Volume Mute</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="406"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="406"/>
         <source>Volume Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="407"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="407"/>
         <source>Bass Boost</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="408"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="408"/>
         <source>Bass Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="409"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="409"/>
         <source>Bass Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="410"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="410"/>
         <source>Treble Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="411"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="411"/>
         <source>Treble Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="412"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="412"/>
         <source>Media Play</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="413"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="413"/>
         <source>Media Stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="414"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="414"/>
         <source>Media Previous</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="415"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="415"/>
         <source>Media Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="416"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="416"/>
         <source>Media Record</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="417"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="417"/>
         <source>Home Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="418"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="418"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="419"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="419"/>
         <source>Search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="420"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="420"/>
         <source>Standby</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="421"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="421"/>
         <source>Open URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="422"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="422"/>
         <source>Launch Mail</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="423"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="423"/>
         <source>Launch Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="424"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="424"/>
         <source>Launch (0)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="425"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="425"/>
         <source>Launch (1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="426"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="426"/>
         <source>Launch (2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="427"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="427"/>
         <source>Launch (3)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="428"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="428"/>
         <source>Launch (4)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="429"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="429"/>
         <source>Launch (5)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="430"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="430"/>
         <source>Launch (6)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="431"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="431"/>
         <source>Launch (7)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="432"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="432"/>
         <source>Launch (8)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="433"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="433"/>
         <source>Launch (9)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="434"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="434"/>
         <source>Launch (A)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="435"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="435"/>
         <source>Launch (B)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="436"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="436"/>
         <source>Launch (C)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="437"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="437"/>
         <source>Launch (D)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="438"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="438"/>
         <source>Launch (E)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="439"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="439"/>
         <source>Launch (F)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="443"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="443"/>
         <source>Print Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="444"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="444"/>
         <source>Page Up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="445"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="445"/>
         <source>Page Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="446"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="446"/>
         <source>Caps Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="447"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="447"/>
         <source>Num Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="448"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="448"/>
         <source>Number Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="449"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="449"/>
         <source>Scroll Lock</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="450"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="450"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="451"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="451"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="452"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="452"/>
         <source>Escape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="453"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="453"/>
         <source>System Request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="457"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="457"/>
         <source>Select</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="458"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="458"/>
         <source>Yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="459"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="459"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="463"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="463"/>
         <source>Context1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="464"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="464"/>
         <source>Context2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="465"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="465"/>
         <source>Context3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="466"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="466"/>
         <source>Context4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="467"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="467"/>
         <source>Call</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="468"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="468"/>
         <source>Hangup</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="469"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="469"/>
         <source>Flip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="994"/>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1116"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="994"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1116"/>
         <source>Ctrl</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="995"/>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1120"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="995"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1120"/>
         <source>Shift</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="996"/>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1118"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="996"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1118"/>
         <source>Alt</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="997"/>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1114"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="997"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1114"/>
         <source>Meta</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1089"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1089"/>
         <source>+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1135"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qkeysequence.cpp" line="1135"/>
         <source>F%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4803,27 +4803,27 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSlider</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="720"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="720"/>
         <source>Page left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="720"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="720"/>
         <source>Page up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="722"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="722"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="725"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="725"/>
         <source>Page right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="725"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="725"/>
         <source>Page down</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4831,72 +4831,72 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSocks5SocketEngine</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="612"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="612"/>
         <source>Connection to proxy refused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="616"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="616"/>
         <source>Connection to proxy closed prematurely</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="620"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="620"/>
         <source>Proxy host not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="625"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="625"/>
         <source>Connection to proxy timed out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="642"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="642"/>
         <source>Proxy authentication failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="643"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="643"/>
         <source>Proxy authentication failed: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="652"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="652"/>
         <source>SOCKS version 5 protocol error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="671"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="671"/>
         <source>General SOCKSv5 server failure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="675"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="675"/>
         <source>Connection not allowed by SOCKSv5 server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="691"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="691"/>
         <source>TTL expired</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="695"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="695"/>
         <source>SOCKSv5 command not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="699"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="699"/>
         <source>Address type not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="704"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="704"/>
         <source>Unknown SOCKSv5 proxy error code 0x%1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="1389"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qsocks5socketengine.cpp" line="1389"/>
         <source>Network operation timed out</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4904,12 +4904,12 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSpinBox</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="151"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="151"/>
         <source>More</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="153"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/rangecontrols.cpp" line="153"/>
         <source>Less</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4917,57 +4917,57 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSslSocket</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="260"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="260"/>
         <source>Error creating SSL context (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="285"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="285"/>
         <source>Invalid or empty cipher list (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="301"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="301"/>
         <source>Cannot provide a certificate with no key, %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="308"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="308"/>
         <source>Error loading local certificate, %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="320"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="320"/>
         <source>Error loading private key, %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="327"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="327"/>
         <source>Private key does not certificate public key, %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="347"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="347"/>
         <source>Error creating SSL session, %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="362"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="362"/>
         <source>Error creating SSL session: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="546"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="546"/>
         <source>Unable to write data: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="665"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="665"/>
         <source>Error while reading: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="761"/>
+        <location filename="../../qtopiacore/qt/src/network/ssl/qsslsocket_openssl.cpp" line="761"/>
         <source>Error during SSL handshake: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4975,30 +4975,30 @@ Do you want to overwrite it?</source>
 <context>
     <name>QSystemSemaphore</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="86"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_win.cpp" line="70"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="86"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_win.cpp" line="70"/>
         <source>%1: permission denied</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="90"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="90"/>
         <source>%1: already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="94"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="94"/>
         <source>%1: does not exist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="99"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_win.cpp" line="66"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="99"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_win.cpp" line="66"/>
         <source>%1: out of resources</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="103"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_win.cpp" line="73"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_unix.cpp" line="103"/>
+        <location filename="../../qtopiacore/qt/src/corelib/kernel/qsystemsemaphore_win.cpp" line="73"/>
         <source>%1: unknown error %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5006,12 +5006,12 @@ Do you want to overwrite it?</source>
 <context>
     <name>QTDSDriver</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/tds/qsql_tds.cpp" line="582"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/tds/qsql_tds.cpp" line="582"/>
         <source>Unable to open connection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/sql/drivers/tds/qsql_tds.cpp" line="587"/>
+        <location filename="../../qtopiacore/qt/src/sql/drivers/tds/qsql_tds.cpp" line="587"/>
         <source>Unable to use database</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5019,12 +5019,12 @@ Do you want to overwrite it?</source>
 <context>
     <name>QTabBar</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1510"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1510"/>
         <source>Scroll Left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1510"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/complexwidgets.cpp" line="1510"/>
         <source>Scroll Right</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5032,7 +5032,7 @@ Do you want to overwrite it?</source>
 <context>
     <name>QTcpServer</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qtcpserver.cpp" line="282"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qtcpserver.cpp" line="282"/>
         <source>Operation on socket is not supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5040,42 +5040,42 @@ Do you want to overwrite it?</source>
 <context>
     <name>QTextControl</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1973"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1973"/>
         <source>&amp;Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1975"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1975"/>
         <source>&amp;Redo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1979"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1979"/>
         <source>Cu&amp;t</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1984"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1984"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1991"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1991"/>
         <source>Copy &amp;Link Location</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1997"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="1997"/>
         <source>&amp;Paste</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2000"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2000"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2007"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2007"/>
         <source>Select All</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5083,14 +5083,14 @@ Do you want to overwrite it?</source>
 <context>
     <name>QToolButton</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="376"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="382"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="376"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="382"/>
         <source>Press</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="378"/>
-        <location filename="../../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="386"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="378"/>
+        <location filename="../../qtopiacore/qt/src/plugins/accessible/widgets/simplewidgets.cpp" line="386"/>
         <source>Open</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5098,7 +5098,7 @@ Do you want to overwrite it?</source>
 <context>
     <name>QUdpSocket</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/network/socket/qudpsocket.cpp" line="172"/>
+        <location filename="../../qtopiacore/qt/src/network/socket/qudpsocket.cpp" line="172"/>
         <source>This platform does not support IPv6</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5106,12 +5106,12 @@ Do you want to overwrite it?</source>
 <context>
     <name>QUndoGroup</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/util/qundogroup.cpp" line="386"/>
+        <location filename="../../qtopiacore/qt/src/gui/util/qundogroup.cpp" line="386"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/util/qundogroup.cpp" line="414"/>
+        <location filename="../../qtopiacore/qt/src/gui/util/qundogroup.cpp" line="414"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5119,7 +5119,7 @@ Do you want to overwrite it?</source>
 <context>
     <name>QUndoModel</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/util/qundoview.cpp" line="101"/>
+        <location filename="../../qtopiacore/qt/src/gui/util/qundoview.cpp" line="101"/>
         <source>&lt;empty&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5127,12 +5127,12 @@ Do you want to overwrite it?</source>
 <context>
     <name>QUndoStack</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/util/qundostack.cpp" line="834"/>
+        <location filename="../../qtopiacore/qt/src/gui/util/qundostack.cpp" line="834"/>
         <source>Undo</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/util/qundostack.cpp" line="861"/>
+        <location filename="../../qtopiacore/qt/src/gui/util/qundostack.cpp" line="861"/>
         <source>Redo</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5140,57 +5140,57 @@ Do you want to overwrite it?</source>
 <context>
     <name>QUnicodeControlCharacterMenu</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2891"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2891"/>
         <source>LRM Left-to-right mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2892"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2892"/>
         <source>RLM Right-to-left mark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2893"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2893"/>
         <source>ZWJ Zero width joiner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2894"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2894"/>
         <source>ZWNJ Zero width non-joiner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2895"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2895"/>
         <source>ZWSP Zero width space</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2896"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2896"/>
         <source>LRE Start of left-to-right embedding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2897"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2897"/>
         <source>RLE Start of right-to-left embedding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2898"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2898"/>
         <source>LRO Start of left-to-right override</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2899"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2899"/>
         <source>RLO Start of right-to-left override</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2900"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2900"/>
         <source>PDF Pop directional formatting</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2906"/>
+        <location filename="../../qtopiacore/qt/src/gui/text/qtextcontrol.cpp" line="2906"/>
         <source>Insert Unicode control character</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5198,32 +5198,32 @@ Do you want to overwrite it?</source>
 <context>
     <name>QWebFrame</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="697"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="697"/>
         <source>Request cancelled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="714"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="714"/>
         <source>Request blocked</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="721"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="721"/>
         <source>Cannot show URL</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="727"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="727"/>
         <source>Frame load interruped by policy change</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="733"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="733"/>
         <source>Cannot show mimetype</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="739"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/FrameLoaderClientQt.cpp" line="739"/>
         <source>File does not exist</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5231,12 +5231,12 @@ Do you want to overwrite it?</source>
 <context>
     <name>QWebPage</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/network/qt/QNetworkReplyHandler.cpp" line="387"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/network/qt/QNetworkReplyHandler.cpp" line="387"/>
         <source>Bad HTTP request</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/FileChooserQt.cpp" line="45"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/FileChooserQt.cpp" line="45"/>
         <source>%n file(s)</source>
         <comment>number of chosen file</comment>
         <translation type="unfinished">
@@ -5244,526 +5244,526 @@ Do you want to overwrite it?</source>
         </translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="42"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="42"/>
         <source>Submit</source>
         <comment>default label for Submit buttons in forms on web pages</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="47"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="47"/>
         <source>Submit</source>
         <comment>Submit (input element) alt text for &lt;input&gt; elements with no alt, title, or value</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="52"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="52"/>
         <source>Reset</source>
         <comment>default label for Reset buttons in forms on web pages</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="62"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="62"/>
         <source>This is a searchable index. Enter search keywords: </source>
         <comment>text that appears at the start of nearly-obsolete web pages in the form of a &apos;searchable index&apos;</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="67"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="67"/>
         <source>Choose File</source>
         <comment>title for file button used in HTML forms</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="72"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="72"/>
         <source>No file selected</source>
         <comment>text to display in file button used in HTML forms when no file is selected</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="77"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="77"/>
         <source>Open in New Window</source>
         <comment>Open in New Window context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="82"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="82"/>
         <source>Save Link...</source>
         <comment>Download Linked File context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="87"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="87"/>
         <source>Copy Link</source>
         <comment>Copy Link context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="92"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="92"/>
         <source>Open Image</source>
         <comment>Open Image in New Window context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="97"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="97"/>
         <source>Save Image</source>
         <comment>Download Image context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="102"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="102"/>
         <source>Copy Image</source>
         <comment>Copy Link context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="107"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="107"/>
         <source>Open Frame</source>
         <comment>Open Frame in New Window context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="112"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="112"/>
         <source>Copy</source>
         <comment>Copy context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="117"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="117"/>
         <source>Go Back</source>
         <comment>Back context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="122"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="122"/>
         <source>Go Forward</source>
         <comment>Forward context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="127"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="127"/>
         <source>Stop</source>
         <comment>Stop context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="132"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="132"/>
         <source>Reload</source>
         <comment>Reload context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="137"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="137"/>
         <source>Cut</source>
         <comment>Cut context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="142"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="142"/>
         <source>Paste</source>
         <comment>Paste context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="147"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="147"/>
         <source>No Guesses Found</source>
         <comment>No Guesses Found context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="152"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="152"/>
         <source>Ignore</source>
         <comment>Ignore Spelling context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="157"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="157"/>
         <source>Add To Dictionary</source>
         <comment>Learn Spelling context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="162"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="162"/>
         <source>Search The Web</source>
         <comment>Search The Web context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="167"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="167"/>
         <source>Look Up In Dictionary</source>
         <comment>Look Up in Dictionary context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="172"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="172"/>
         <source>Open Link</source>
         <comment>Open Link context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="177"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="177"/>
         <source>Ignore</source>
         <comment>Ignore Grammar context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="182"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="182"/>
         <source>Spelling</source>
         <comment>Spelling and Grammar context sub-menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="187"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="187"/>
         <source>Show Spelling and Grammar</source>
         <comment>menu item title</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="188"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="188"/>
         <source>Hide Spelling and Grammar</source>
         <comment>menu item title</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="193"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="193"/>
         <source>Check Spelling</source>
         <comment>Check spelling context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="198"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="198"/>
         <source>Check Spelling While Typing</source>
         <comment>Check spelling while typing context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="203"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="203"/>
         <source>Check Grammar With Spelling</source>
         <comment>Check grammar with spelling context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="208"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="208"/>
         <source>Fonts</source>
         <comment>Font context sub-menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="213"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="213"/>
         <source>Bold</source>
         <comment>Bold context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="218"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="218"/>
         <source>Italic</source>
         <comment>Italic context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="223"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="223"/>
         <source>Underline</source>
         <comment>Underline context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="228"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="228"/>
         <source>Outline</source>
         <comment>Outline context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="233"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="233"/>
         <source>Direction</source>
         <comment>Writing direction context sub-menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="238"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="238"/>
         <source>Text Direction</source>
         <comment>Text direction context sub-menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="243"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="243"/>
         <source>Default</source>
         <comment>Default writing direction context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="248"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="248"/>
         <source>LTR</source>
         <comment>Left to Right context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="253"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="253"/>
         <source>RTL</source>
         <comment>Right to Left context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="258"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="258"/>
         <source>Inspect</source>
         <comment>Inspect Element context menu item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="263"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="263"/>
         <source>No recent searches</source>
         <comment>Label for only item in menu that appears when clicking on the search field image, when no searches have been performed</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="268"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="268"/>
         <source>Recent searches</source>
         <comment>label for first item in the menu that appears when clicking on the search field image, used as embedded menu title</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="273"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="273"/>
         <source>Clear recent searches</source>
         <comment>menu item in Recent Searches menu that empties menu&apos;s contents</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="348"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="348"/>
         <source>Unknown</source>
         <comment>Unknown filesize FTP directory listing item</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="353"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/Localizations.cpp" line="353"/>
         <source>%1 (%2x%3 pixels)</source>
         <comment>Title string for images</comment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="58"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="58"/>
         <source>Scroll here</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="61"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="61"/>
         <source>Left edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="61"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="61"/>
         <source>Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="62"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="62"/>
         <source>Right edge</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="62"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="62"/>
         <source>Bottom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="65"/>
         <source>Page left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="65"/>
         <source>Page up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="66"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="66"/>
         <source>Page right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="66"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="66"/>
         <source>Page down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="69"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="69"/>
         <source>Scroll left</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="69"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="69"/>
         <source>Scroll up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="70"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="70"/>
         <source>Scroll right</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="70"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebCore/platform/qt/ScrollbarQt.cpp" line="70"/>
         <source>Scroll down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1322"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1322"/>
         <source>JavaScript Alert - %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1337"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1337"/>
         <source>JavaScript Confirm - %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1354"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1354"/>
         <source>JavaScript Prompt - %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1694"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1694"/>
         <source>Move the cursor to the next character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1697"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1697"/>
         <source>Move the cursor to the previous character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1700"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1700"/>
         <source>Move the cursor to the next word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1703"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1703"/>
         <source>Move the cursor to the previous word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1706"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1706"/>
         <source>Move the cursor to the next line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1709"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1709"/>
         <source>Move the cursor to the previous line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1712"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1712"/>
         <source>Move the cursor to the start of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1715"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1715"/>
         <source>Move the cursor to the end of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1718"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1718"/>
         <source>Move the cursor to the start of the block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1721"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1721"/>
         <source>Move the cursor to the end of the block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1724"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1724"/>
         <source>Move the cursor to the start of the document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1727"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1727"/>
         <source>Move the cursor to the end of the document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1730"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1730"/>
         <source>Select all</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1733"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1733"/>
         <source>Select to the next character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1736"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1736"/>
         <source>Select to the previous character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1739"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1739"/>
         <source>Select to the next word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1742"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1742"/>
         <source>Select to the previous word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1745"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1745"/>
         <source>Select to the next line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1748"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1748"/>
         <source>Select to the previous line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1751"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1751"/>
         <source>Select to the start of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1754"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1754"/>
         <source>Select to the end of the line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1757"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1757"/>
         <source>Select to the start of the block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1760"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1760"/>
         <source>Select to the end of the block</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1763"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1763"/>
         <source>Select to the start of the document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1766"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1766"/>
         <source>Select to the end of the document</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1769"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1769"/>
         <source>Delete to the start of the word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1772"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1772"/>
         <source>Delete to the end of the word</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1805"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1805"/>
         <source>Insert a new paragraph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1808"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/Api/qwebpage.cpp" line="1808"/>
         <source>Insert a new line</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/InspectorClientQt.cpp" line="185"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/webkit/WebKit/qt/WebCoreSupport/InspectorClientQt.cpp" line="185"/>
         <source>Web Inspector - %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5771,7 +5771,7 @@ Do you want to overwrite it?</source>
 <context>
     <name>QWhatsThisAction</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qwhatsthis.cpp" line="522"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qwhatsthis.cpp" line="522"/>
         <source>What&apos;s This?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5779,7 +5779,7 @@ Do you want to overwrite it?</source>
 <context>
     <name>QWidget</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/kernel/qwidget.cpp" line="5358"/>
+        <location filename="../../qtopiacore/qt/src/gui/kernel/qwidget.cpp" line="5358"/>
         <source>*</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5787,57 +5787,57 @@ Do you want to overwrite it?</source>
 <context>
     <name>QWizard</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="638"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="638"/>
         <source>Go Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="638"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="638"/>
         <source>&lt; &amp;Back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="641"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="641"/>
         <source>Continue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="644"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="644"/>
         <source>&amp;Next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="644"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="644"/>
         <source>&amp;Next &gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="646"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="646"/>
         <source>Commit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="648"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="648"/>
         <source>Done</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="648"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="648"/>
         <source>&amp;Finish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="650"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="650"/>
         <source>Cancel</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="652"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="652"/>
         <source>Help</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="652"/>
+        <location filename="../../qtopiacore/qt/src/gui/dialogs/qwizard.cpp" line="652"/>
         <source>&amp;Help</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5845,69 +5845,69 @@ Do you want to overwrite it?</source>
 <context>
     <name>QWorkspace</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="113"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="113"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="115"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="115"/>
         <source>Minimize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="117"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="117"/>
         <source>Restore Down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1094"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1094"/>
         <source>&amp;Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1095"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1095"/>
         <source>&amp;Move</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1096"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1096"/>
         <source>&amp;Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1098"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1098"/>
         <source>Mi&amp;nimize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1100"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1100"/>
         <source>Ma&amp;ximize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1102"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1102"/>
         <source>&amp;Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1108"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1108"/>
         <source>Stay on &amp;Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1111"/>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="2170"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1111"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="2170"/>
         <source>Sh&amp;ade</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1892"/>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1952"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1892"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="1952"/>
         <source>%1 - [%2]</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="2166"/>
+        <location filename="../../qtopiacore/qt/src/gui/widgets/qworkspace.cpp" line="2166"/>
         <source>&amp;Unshade</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5915,117 +5915,117 @@ Do you want to overwrite it?</source>
 <context>
     <name>QXml</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="58"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="58"/>
         <source>no error occurred</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="59"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="59"/>
         <source>error triggered by consumer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="60"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="60"/>
         <source>unexpected end of file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="61"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="61"/>
         <source>more than one document type definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="62"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="62"/>
         <source>error occurred while parsing element</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="63"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="63"/>
         <source>tag mismatch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="64"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="64"/>
         <source>error occurred while parsing content</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="65"/>
         <source>unexpected character</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="66"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="66"/>
         <source>invalid name for processing instruction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="67"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="67"/>
         <source>version expected while reading the XML declaration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="68"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="68"/>
         <source>wrong value for standalone declaration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="69"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="69"/>
         <source>encoding declaration or standalone declaration expected while reading the XML declaration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="70"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="70"/>
         <source>standalone declaration expected while reading the XML declaration</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="71"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="71"/>
         <source>error occurred while parsing document type definition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="72"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="72"/>
         <source>letter is expected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="73"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="73"/>
         <source>error occurred while parsing comment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="74"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="74"/>
         <source>error occurred while parsing reference</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="75"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="75"/>
         <source>internal general entity reference not allowed in DTD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="76"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="76"/>
         <source>external parsed general entity reference not allowed in attribute value</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="77"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="77"/>
         <source>external parsed general entity reference not allowed in DTD</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="78"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="78"/>
         <source>unparsed entity reference in wrong context</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="79"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="79"/>
         <source>recursive entities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="80"/>
+        <location filename="../../qtopiacore/qt/src/xml/sax/qxml.cpp" line="80"/>
         <source>error in the text declaration of an external entity</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6033,184 +6033,184 @@ Do you want to overwrite it?</source>
 <context>
     <name>QXmlStream</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="592"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1769"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="592"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1769"/>
         <source>Extra content at end of document.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="814"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="814"/>
         <source>Invalid entity value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="921"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="921"/>
         <source>Invalid XML character.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1180"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1180"/>
         <source>Sequence &apos;]]&gt;&apos; not allowed in content.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1459"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1078"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1459"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1078"/>
         <source>Encountered incorrectly encoded content.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1489"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1489"/>
         <source>Namespace prefix &apos;%1&apos; not declared</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1522"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1534"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1690"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1743"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1522"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1534"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1690"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1743"/>
         <source>Illegal namespace declaration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1567"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1567"/>
         <source>Attribute redefined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1682"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1682"/>
         <source>Unexpected character &apos;%1&apos; in public id literal.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1710"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1710"/>
         <source>Invalid XML version string.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1712"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1712"/>
         <source>Unsupported XML version.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1733"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1733"/>
         <source>The standalone pseudo attribute must appear after the encoding.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1735"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1735"/>
         <source>%1 is an invalid encoding name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1742"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1742"/>
         <source>Encoding %1 is unsupported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1758"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1758"/>
         <source>Standalone accepts only yes or no.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1760"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1760"/>
         <source>Invalid attribute in XML declaration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1776"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1776"/>
         <source>Premature end of document.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1778"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1778"/>
         <source>Invalid document.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1818"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1818"/>
         <source>Expected </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1829"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1829"/>
         <source>, but got &apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1833"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="1833"/>
         <source>Unexpected &apos;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="2043"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream.cpp" line="2043"/>
         <source>Expected character data.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="774"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="774"/>
         <source>Recursive entity detected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1290"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1290"/>
         <source>Start tag expected.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1481"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1481"/>
         <source>NDATA in parameter entity declaration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1512"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1512"/>
         <source>XML declaration not at start of document.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1515"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1515"/>
         <source>%1 is an invalid processing instruction name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1526"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1526"/>
         <source>Invalid processing instruction name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1640"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1640"/>
         <source>%1 is an invalid PUBLIC identifier.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1758"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1758"/>
         <source>Invalid XML name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1781"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1781"/>
         <source>Opening and ending tag mismatch.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1786"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1847"/>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1887"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1786"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1847"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1887"/>
         <source>Entity &apos;%1&apos; not declared.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1799"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1799"/>
         <source>Reference to unparsed entity &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1861"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1861"/>
         <source>Reference to external entity &apos;%1&apos; in attribute value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1901"/>
+        <location filename="../../qtopiacore/qt/src/corelib/xml/qxmlstream_p.h" line="1901"/>
         <source>Invalid character reference.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6218,1038 +6218,1038 @@ Do you want to overwrite it?</source>
 <context>
     <name>QtXmlPatterns</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreebuilder.cpp" line="205"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreebuilder.cpp" line="205"/>
         <source>An %1-attribute with value %2 has already been declared.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreebuilder.cpp" line="218"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreebuilder.cpp" line="218"/>
         <source>An %1-attribute must have a valid %2 as value, which %3 isn&apos;t.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreeresourceloader.cpp" line="314"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreeresourceloader.cpp" line="314"/>
         <source>%1 is an unsupported encoding.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreeresourceloader.cpp" line="330"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreeresourceloader.cpp" line="330"/>
         <source>%1 contains octets which are disallowed in the requested encoding %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreeresourceloader.cpp" line="348"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/acceltree/qacceltreeresourceloader.cpp" line="348"/>
         <source>The codepoint %1, occurring in %2 using encoding %3, is an invalid XML character.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/api/qiodevicedelegate.cpp" line="84"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/api/qiodevicedelegate.cpp" line="84"/>
         <source>Network timeout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/api/qxmlserializer.cpp" line="320"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/api/qxmlserializer.cpp" line="320"/>
         <source>Element %1 can&apos;t be serialized because it appears outside the document element.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/api/qxmlserializer.cpp" line="380"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/api/qxmlserializer.cpp" line="380"/>
         <source>Attribute %1 can&apos;t be serialized because it appears at the top level.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="80"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="80"/>
         <source>Year %1 is invalid because it begins with %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="99"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="99"/>
         <source>Day %1 is outside the range %2..%3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="106"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="106"/>
         <source>Month %1 is outside the range %2..%3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="116"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="116"/>
         <source>Overflow: Can&apos;t represent date %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="125"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="125"/>
         <source>Day %1 is invalid for month %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="174"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="174"/>
         <source>Time 24:%1:%2.%3 is invalid. Hour is 24, but minutes, seconds, and milliseconds are not all 0; </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="187"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="187"/>
         <source>Time %1:%2:%3.%4 is invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="302"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractdatetime.cpp" line="302"/>
         <source>Overflow: Date can&apos;t be represented.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractduration.cpp" line="99"/>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractduration.cpp" line="114"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractduration.cpp" line="99"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractduration.cpp" line="114"/>
         <source>At least one component must be present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractduration.cpp" line="107"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractduration.cpp" line="107"/>
         <source>At least one time component must appear after the %1-delimiter.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractfloatmathematician.cpp" line="64"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractfloatmathematician.cpp" line="64"/>
         <source>No operand in an integer division, %1, can be %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractfloatmathematician.cpp" line="71"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractfloatmathematician.cpp" line="71"/>
         <source>The first operand in an integer division, %1, cannot be infinity (%2).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qabstractfloatmathematician.cpp" line="77"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qabstractfloatmathematician.cpp" line="77"/>
         <source>The second operand in a division, %1, cannot be zero (%2).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qanyuri_p.h" line="132"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qanyuri_p.h" line="132"/>
         <source>%1 is not a valid value of type %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomiccasters_p.h" line="223"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomiccasters_p.h" line="223"/>
         <source>When casting to %1 from %2, the source value cannot be %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="65"/>
         <source>Integer division (%1) by zero (%2) is undefined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="72"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="72"/>
         <source>Division (%1) by zero (%2) is undefined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="79"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="79"/>
         <source>Modulus division (%1) by zero (%2) is undefined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="201"/>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="233"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="201"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="233"/>
         <source>Dividing a value of type %1 by %2 (not-a-number) is not allowed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="213"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="213"/>
         <source>Dividing a value of type %1 by %2 or %3 (plus or minus zero) is not allowed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="245"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomicmathematicians.cpp" line="245"/>
         <source>Multiplication of a value of type %1 by %2 or %3 (plus or minus infinity) is not allowed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qatomicvalue.cpp" line="79"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qatomicvalue.cpp" line="79"/>
         <source>A value of type %1 cannot have an Effective Boolean Value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qboolean.cpp" line="78"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qboolean.cpp" line="78"/>
         <source>Effective Boolean Value cannot be calculated for a sequence containing two or more atomic values.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qderivedinteger_p.h" line="402"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qderivedinteger_p.h" line="402"/>
         <source>Value %1 of type %2 exceeds maximum (%3).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qderivedinteger_p.h" line="411"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qderivedinteger_p.h" line="411"/>
         <source>Value %1 of type %2 is below minimum (%3).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qhexbinary.cpp" line="91"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qhexbinary.cpp" line="91"/>
         <source>A value of type %1 must contain an even number of digits. The value %2 does not.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/data/qhexbinary.cpp" line="110"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/data/qhexbinary.cpp" line="110"/>
         <source>%1 is not valid as a value of type %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qapplytemplate.cpp" line="119"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qapplytemplate.cpp" line="119"/>
         <source>Ambiguous rule match.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qarithmeticexpression.cpp" line="207"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qarithmeticexpression.cpp" line="207"/>
         <source>Operator %1 cannot be used on type %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qarithmeticexpression.cpp" line="224"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qarithmeticexpression.cpp" line="224"/>
         <source>Operator %1 cannot be used on atomic values of type %2 and %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qattributenamevalidator.cpp" line="66"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qattributenamevalidator.cpp" line="66"/>
         <source>The namespace URI in the name for a computed attribute cannot be %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qattributenamevalidator.cpp" line="75"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qattributenamevalidator.cpp" line="75"/>
         <source>The name for a computed attribute cannot have the namespace URI %1 with the local name %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcastas.cpp" line="88"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcastas.cpp" line="88"/>
         <source>Type error in cast, expected %1, received %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcastas.cpp" line="117"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcastas.cpp" line="117"/>
         <source>When casting to %1 or types derived from it, the source value must be of the same type, or it must be a string literal. Type %2 is not allowed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="134"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="134"/>
         <source>No casting is possible with %1 as the target type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="149"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="149"/>
         <source>It is not possible to cast from %1 to %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="176"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="176"/>
         <source>Casting to %1 is not possible because it is an abstract type, and can therefore never be instantiated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="199"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="199"/>
         <source>It&apos;s not possible to cast the value %1 of type %2 to %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="207"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcastingplatform.cpp" line="207"/>
         <source>Failure when casting from %1 to %2: %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcommentconstructor.cpp" line="67"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcommentconstructor.cpp" line="67"/>
         <source>A comment cannot contain %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcommentconstructor.cpp" line="73"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcommentconstructor.cpp" line="73"/>
         <source>A comment cannot end with a %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcomparisonplatform.cpp" line="167"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcomparisonplatform.cpp" line="167"/>
         <source>No comparisons can be done involving the type %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcomparisonplatform.cpp" line="181"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcomparisonplatform.cpp" line="181"/>
         <source>Operator %1 is not available between atomic values of type %2 and %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcomputednamespaceconstructor.cpp" line="69"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcomputednamespaceconstructor.cpp" line="69"/>
         <source>In a namespace constructor, the value for a namespace cannot be an empty string.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcomputednamespaceconstructor.cpp" line="80"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcomputednamespaceconstructor.cpp" line="80"/>
         <source>The prefix must be a valid %1, which %2 is not.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcomputednamespaceconstructor.cpp" line="94"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcomputednamespaceconstructor.cpp" line="94"/>
         <source>The prefix %1 cannot be bound.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qcomputednamespaceconstructor.cpp" line="104"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qcomputednamespaceconstructor.cpp" line="104"/>
         <source>Only the prefix %1 can be bound to %2 and vice versa.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qdocumentcontentvalidator.cpp" line="86"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qdocumentcontentvalidator.cpp" line="86"/>
         <source>An attribute node cannot be a child of a document node. Therefore, the attribute %1 is out of place.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qevaluationcache.cpp" line="117"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qevaluationcache.cpp" line="117"/>
         <source>Circularity detected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qexpressionfactory.cpp" line="169"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qexpressionfactory.cpp" line="169"/>
         <source>A library module cannot be evaluated directly. It must be imported from a main module.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qexpressionfactory.cpp" line="209"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qexpressionfactory.cpp" line="209"/>
         <source>No template by name %1 exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qgenericpredicate.cpp" line="106"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qgenericpredicate.cpp" line="106"/>
         <source>A value of type %1 cannot be a predicate. A predicate must have either a numeric type or an Effective Boolean Value type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qgenericpredicate.cpp" line="138"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qgenericpredicate.cpp" line="138"/>
         <source>A positional predicate must evaluate to a single numeric value.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qncnameconstructor_p.h" line="113"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qncnameconstructor_p.h" line="113"/>
         <source>The target name in a processing instruction cannot be %1 in any combination of upper and lower case. Therefore, is %2 invalid.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qncnameconstructor_p.h" line="137"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qncnameconstructor_p.h" line="137"/>
         <source>%1 is not a valid target name in a processing instruction. It must be a %2 value, e.g. %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qpath.cpp" line="109"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qpath.cpp" line="109"/>
         <source>The last step in a path must contain either nodes or atomic values. It cannot be a mixture between the two.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qprocessinginstructionconstructor.cpp" line="84"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qprocessinginstructionconstructor.cpp" line="84"/>
         <source>The data of a processing instruction cannot contain the string %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qqnameconstructor.cpp" line="82"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qqnameconstructor.cpp" line="82"/>
         <source>No namespace binding exists for the prefix %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qqnameconstructor_p.h" line="156"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qqnameconstructor_p.h" line="156"/>
         <source>No namespace binding exists for the prefix %1 in %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qqnameconstructor_p.h" line="168"/>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qqnamefns.cpp" line="69"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qqnameconstructor_p.h" line="168"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qqnamefns.cpp" line="69"/>
         <source>%1 is an invalid %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qtemplate.cpp" line="74"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qtemplate.cpp" line="74"/>
         <source>The parameter %1 is passed, but no corresponding %2 exists.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/expr/qtemplate.cpp" line="145"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/expr/qtemplate.cpp" line="145"/>
         <source>The parameter %1 is required, but no corresponding %2 is supplied.</source>
         <translation type="unfinished"></translation>
     </message>
     <message numerus="yes">
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qabstractfunctionfactory.cpp" line="77"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qabstractfunctionfactory.cpp" line="77"/>
         <source>%1 takes at most %n argument(s). %2 is therefore invalid.</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message numerus="yes">
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qabstractfunctionfactory.cpp" line="88"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qabstractfunctionfactory.cpp" line="88"/>
         <source>%1 requires at least %n argument(s). %2 is therefore invalid.</source>
         <translation type="unfinished">
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qaggregatefns.cpp" line="120"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qaggregatefns.cpp" line="120"/>
         <source>The first argument to %1 cannot be of type %2. It must be a numeric type, xs:yearMonthDuration or xs:dayTimeDuration.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qaggregatefns.cpp" line="194"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qaggregatefns.cpp" line="194"/>
         <source>The first argument to %1 cannot be of type %2. It must be of type %3, %4, or %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qaggregatefns.cpp" line="285"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qaggregatefns.cpp" line="285"/>
         <source>The second argument to %1 cannot be of type %2. It must be of type %3, %4, or %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qassemblestringfns.cpp" line="88"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qassemblestringfns.cpp" line="88"/>
         <source>%1 is not a valid XML 1.0 character.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qcomparingaggregator.cpp" line="197"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qcomparingaggregator.cpp" line="197"/>
         <source>The first argument to %1 cannot be of type %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qcontextnodechecker.cpp" line="54"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qcontextnodechecker.cpp" line="54"/>
         <source>The root node of the second argument to function %1 must be a document node. %2 is not a document node.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qdatetimefn.cpp" line="86"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qdatetimefn.cpp" line="86"/>
         <source>If both values have zone offsets, they must have the same zone offset. %1 and %2 are not the same.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qerrorfn.cpp" line="61"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qerrorfn.cpp" line="61"/>
         <source>%1 was called.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternmatchingfns.cpp" line="94"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternmatchingfns.cpp" line="94"/>
         <source>%1 must be followed by %2 or %3, not at the end of the replacement string.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternmatchingfns.cpp" line="133"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternmatchingfns.cpp" line="133"/>
         <source>In the replacement string, %1 must be followed by at least one digit when not escaped.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternmatchingfns.cpp" line="159"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternmatchingfns.cpp" line="159"/>
         <source>In the replacement string, %1 can only be used to escape itself or %2, not %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="92"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="92"/>
         <source>%1 matches newline characters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="96"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="96"/>
         <source>%1 and %2 match the start and end of a line.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="102"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="102"/>
         <source>Matches are case insensitive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="106"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="106"/>
         <source>Whitespace characters are removed, except when they appear in character classes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="205"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="205"/>
         <source>%1 is an invalid regular expression pattern: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="235"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qpatternplatform.cpp" line="235"/>
         <source>%1 is an invalid flag for regular expressions. Valid flags are:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qqnamefns.cpp" line="86"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qqnamefns.cpp" line="86"/>
         <source>If the first argument is the empty sequence or a zero-length string (no namespace), a prefix cannot be specified. Prefix %1 was specified.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qsequencefns.cpp" line="346"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qsequencefns.cpp" line="346"/>
         <source>It will not be possible to retrieve %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qsequencegeneratingfns.cpp" line="279"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qsequencegeneratingfns.cpp" line="279"/>
         <source>The default collection is undefined</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qsequencegeneratingfns.cpp" line="292"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qsequencegeneratingfns.cpp" line="292"/>
         <source>%1 cannot be retrieved</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qstringvaluefns.cpp" line="252"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qstringvaluefns.cpp" line="252"/>
         <source>The normalization form %1 is unsupported. The supported forms are %2, %3, %4, and %5, and none, i.e. the empty string (no normalization).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qtimezonefns.cpp" line="87"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qtimezonefns.cpp" line="87"/>
         <source>A zone offset must be in the range %1..%2 inclusive. %3 is out of range.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qtimezonefns.cpp" line="99"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qtimezonefns.cpp" line="99"/>
         <source>%1 is not a whole number of minutes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/functions/qunparsedtextfn.cpp" line="65"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/functions/qunparsedtextfn.cpp" line="65"/>
         <source>The URI cannot have a fragment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/janitors/qcardinalityverifier.cpp" line="58"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/janitors/qcardinalityverifier.cpp" line="58"/>
         <source>Required cardinality is %1; got cardinality %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/janitors/qitemverifier.cpp" line="67"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/janitors/qitemverifier.cpp" line="67"/>
         <source>The item %1 did not match the required type %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="183"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="183"/>
         <source>Attribute %1 cannot appear on the element %2. Only the standard attributes can appear.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="189"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="189"/>
         <source>Attribute %1 cannot appear on the element %2. Only %3 is allowed, and the standard attributes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="197"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="197"/>
         <source>Attribute %1 cannot appear on the element %2. Allowed is %3, %4, and the standard attributes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="206"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="206"/>
         <source>Attribute %1 cannot appear on the element %2. Allowed is %3, and the standard attributes.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="219"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="219"/>
         <source>XSL-T attributes on XSL-T elements must be in the null namespace, not in the XSL-T namespace which %1 is.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="231"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="231"/>
         <source>The attribute %1 must appear on element %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="239"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qmaintainingreader.cpp" line="239"/>
         <source>The element with local name %1 does not exist in XSL-T.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qparsercontext.cpp" line="93"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qparsercontext.cpp" line="93"/>
         <source>The variable %1 is unused</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="269"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="269"/>
         <source>A construct was encountered which only is allowed in XQuery.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="318"/>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7571"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="318"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7571"/>
         <source>%1 is an unknown schema type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="387"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="387"/>
         <source>A template by name %1 has already been declared.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="413"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="413"/>
         <source>%1 is not a valid numeric literal.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="600"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="600"/>
         <source>Only one %1 declaration can occur in the query prolog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="788"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="788"/>
         <source>The initialization of variable %1 depends on itself</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="851"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="851"/>
         <source>No variable by name %1 exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3692"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3692"/>
         <source>Version %1 is not supported. The supported XQuery version is 1.0.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3708"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3708"/>
         <source>The encoding %1 is invalid. It must contain Latin characters only, must not contain whitespace, and must match the regular expression %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3763"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3763"/>
         <source>No function with signature %1 is available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3835"/>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3845"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3835"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3845"/>
         <source>A default namespace declaration must occur before function, variable, and option declarations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3855"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3855"/>
         <source>Namespace declarations must occur before function, variable, and option declarations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3866"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3866"/>
         <source>Module imports must occur before function, variable, and option declarations.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3968"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3968"/>
         <source>The keyword %1 cannot occur with any other mode name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3997"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="3997"/>
         <source>The value of attribute %1 must of type %2, which %3 isn&apos;t.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4066"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4066"/>
         <source>It is not possible to redeclare prefix %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4072"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4072"/>
         <source>The prefix %1 can not be bound. By default, it is already bound to the namespace %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4084"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4084"/>
         <source>Prefix %1 is already declared in the prolog.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4179"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4179"/>
         <source>The name of an option must have a prefix. There is no default namespace for options.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4350"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4350"/>
         <source>The Schema Import feature is not supported, and therefore %1 declarations cannot occur.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4363"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4363"/>
         <source>The target namespace of a %1 cannot be empty.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4371"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4371"/>
         <source>The module import feature is not supported</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4384"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4384"/>
         <source>A variable by name %1 has already been declared.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4423"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4423"/>
         <source>No value is available for the external variable by name %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4519"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4519"/>
         <source>A stylesheet function must have a prefixed name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4528"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4528"/>
         <source>The namespace for a user defined function cannot be empty (try the predefined prefix %1 which exists for cases like this)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4537"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4537"/>
         <source>The namespace %1 is reserved; therefore user defined functions may not use it. Try the predefined prefix %2, which exists for these cases.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4549"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4549"/>
         <source>The namespace of a user defined function in a library module must be equivalent to the module namespace. In other words, it should be %1 instead of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4583"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4583"/>
         <source>A function already exists with the signature %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4606"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4606"/>
         <source>No external functions are supported. All supported functions can be used directly, without first declaring them as external</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4643"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4643"/>
         <source>An argument by name %1 has already been declared. Every argument name must be unique.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4822"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4822"/>
         <source>When function %1 is used for matching inside a pattern, the argument must be a variable reference or a string literal.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4833"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4833"/>
         <source>In an XSL-T pattern, the first argument to function %1 must be a string literal, when used for matching.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4847"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4847"/>
         <source>In an XSL-T pattern, the first argument to function %1 must be a literal or a variable reference, when used for matching.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4856"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4856"/>
         <source>In an XSL-T pattern, function %1 cannot have a third argument.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4866"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4866"/>
         <source>In an XSL-T pattern, only function %1 and %2, not %3, can be used for matching.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4929"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="4929"/>
         <source>In an XSL-T pattern, axis %1 cannot be used, only axis %2 or %3 can.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="5055"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="5055"/>
         <source>%1 is an invalid template mode name.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="5099"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="5099"/>
         <source>The name of a variable bound in a for-expression must be different from the positional variable. Hence, the two variables named %1 collide.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="5857"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="5857"/>
         <source>The Schema Validation Feature is not supported. Hence, %1-expressions may not be used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="5896"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="5896"/>
         <source>None of the pragma expressions are supported. Therefore, a fallback expression must be present</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6163"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6163"/>
         <source>Each name of a template parameter must be unique; %1 is duplicated.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6292"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6292"/>
         <source>The %1-axis is unsupported in XQuery</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6578"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6578"/>
         <source>No function by name %1 is available.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6680"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6680"/>
         <source>The namespace URI cannot be the empty string when binding to a prefix, %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6687"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6687"/>
         <source>%1 is an invalid namespace URI.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6693"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6693"/>
         <source>It is not possible to bind to the prefix %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6700"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6700"/>
         <source>Namespace %1 can only be bound to %2 (and it is, in either case, pre-declared).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6708"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6708"/>
         <source>Prefix %1 can only be bound to %2 (and it is, in either case, pre-declared).</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6723"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6723"/>
         <source>Two namespace declaration attributes have the same name: %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6812"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6812"/>
         <source>The namespace URI must be a constant and cannot use enclosed expressions.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6828"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6828"/>
         <source>An attribute by name %1 has already appeared on this element.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6889"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="6889"/>
         <source>A direct element constructor is not well-formed. %1 is ended with %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7347"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7347"/>
         <source>The name %1 does not refer to any schema type.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7357"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7357"/>
         <source>%1 is an complex type. Casting to complex types is not possible. However, casting to atomic types such as %2 works.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7366"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7366"/>
         <source>%1 is not an atomic type. Casting is only possible to atomic types.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7442"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7442"/>
         <source>%1 is not a valid name for a processing-instruction.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7511"/>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7582"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7511"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7582"/>
         <source>%1 is not in the in-scope attribute declarations. Note that the schema import feature is not supported.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7630"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qquerytransformparser.cpp" line="7630"/>
         <source>The name of an extension expression must be in a namespace.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="519"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="519"/>
         <source>Element %1 is not allowed at this location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="528"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="528"/>
         <source>Text nodes are not allowed at this location.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="548"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="548"/>
         <source>Parse error: %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="610"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="610"/>
         <source>The value of the XSL-T version attribute must be a value of type %1, which %2 isn&apos;t.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="630"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="630"/>
         <source>Running an XSL-T 1.0 stylesheet with a 2.0 processor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="738"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="738"/>
         <source>Unknown XSL-T attribute %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="761"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="761"/>
         <source>Attribute %1 and %2 are mutually exclusive.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="927"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="927"/>
         <source>In a simplified stylesheet module, attribute %1 must be present.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="999"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="999"/>
         <source>If element %1 has no attribute %2, it cannot have attribute %3 or %4.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1008"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1008"/>
         <source>Element %1 must have at least one of the attributes %2 or %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1036"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1036"/>
         <source>At least one mode must be specified in the %1-attribute on element %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1159"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1159"/>
         <source>Element %1 must come last.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1183"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1183"/>
         <source>At least one %1-element must occur before %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1190"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1190"/>
         <source>Only one %1-element can appear.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1221"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1221"/>
         <source>At least one %1-element must occur inside %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1279"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1279"/>
         <source>When attribute %1 is present on %2, a sequence constructor cannot be used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1292"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1292"/>
         <source>Element %1 must have either a %2-attribute or a sequence constructor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1417"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1417"/>
         <source>When a parameter is required, a default value cannot be supplied through a %1-attribute or a sequence constructor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1687"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="1687"/>
         <source>Element %1 cannot have children.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2121"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2121"/>
         <source>Element %1 cannot have a sequence constructor.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2207"/>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2216"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2207"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2216"/>
         <source>The attribute %1 cannot appear on %2, when it is a child of %3.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2231"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2231"/>
         <source>A parameter in a function cannot be declared to be a tunnel.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2380"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2380"/>
         <source>This processor is not Schema-aware and therefore %1 cannot be used.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2437"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2437"/>
         <source>Top level stylesheet elements must be in a non-null namespace, which %1 isn&apos;t.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2485"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2485"/>
         <source>The value for attribute %1 on element %2 must either be %3 or %4, not %5.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2505"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2505"/>
         <source>Attribute %1 cannot have the value %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2563"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2563"/>
         <source>The attribute %1 can only appear on the first %2 element.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2662"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/parser/qxslttokenizer.cpp" line="2662"/>
         <source>At least one %1 element must appear as child of %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="55"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="55"/>
         <source>empty</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="57"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="57"/>
         <source>zero or one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="59"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="59"/>
         <source>exactly one</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="61"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="61"/>
         <source>one or more</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="63"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/type/qcardinality.cpp" line="63"/>
         <source>zero or more</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/type/qtypechecker.cpp" line="63"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/type/qtypechecker.cpp" line="63"/>
         <source>Required type is %1, but %2 was found.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/type/qtypechecker.cpp" line="107"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/type/qtypechecker.cpp" line="107"/>
         <source>Promoting %1 to %2 may cause loss of precision.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/type/qtypechecker.cpp" line="156"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/type/qtypechecker.cpp" line="156"/>
         <source>The focus is undefined.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/utils/qoutputvalidator.cpp" line="86"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/utils/qoutputvalidator.cpp" line="86"/>
         <source>It&apos;s not possible to add attributes after any other kind of node.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/utils/qoutputvalidator.cpp" line="93"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/utils/qoutputvalidator.cpp" line="93"/>
         <source>An attribute by name %1 has already been created.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/xmlpatterns/utils/qxpathhelper_p.h" line="120"/>
+        <location filename="../../qtopiacore/qt/src/xmlpatterns/utils/qxpathhelper_p.h" line="120"/>
         <source>Only the Unicode Codepoint Collation is supported(%1). %2 is unsupported.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7257,13 +7257,13 @@ Do you want to overwrite it?</source>
 <context>
     <name>VolumeSlider</name>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="184"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="184"/>
         <source>Muted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="189"/>
-        <location filename="../../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="204"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="189"/>
+        <location filename="../../qtopiacore/qt/src/3rdparty/phonon/phonon/volumeslider.cpp" line="204"/>
         <source>Volume: %1%</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/server/main/qpe-cs_CZ.ts
+++ b/src/server/main/qpe-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/server/main/qpe-da_DK.ts
+++ b/src/server/main/qpe-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/server/main/qpe-de_DE.ts
+++ b/src/server/main/qpe-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/server/main/qpe-en_US.ts
+++ b/src/server/main/qpe-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/server/main/qpe-es_ES.ts
+++ b/src/server/main/qpe-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/server/main/qpe-fr_FR.ts
+++ b/src/server/main/qpe-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/server/main/qpe-it_IT.ts
+++ b/src/server/main/qpe-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/server/main/qpe-pl_PL.ts
+++ b/src/server/main/qpe-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/server/main/qpe-ru_RU.ts
+++ b/src/server/main/qpe-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>AlarmServer</name>
     <message>

--- a/src/settings/appearance/appearance-da_DK.ts
+++ b/src/settings/appearance/appearance-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AppearanceSettings</name>
     <message>

--- a/src/settings/appearance/appearance-de_DE.ts
+++ b/src/settings/appearance/appearance-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AppearanceSettings</name>
     <message>

--- a/src/settings/appearance/appearance-en_US.ts
+++ b/src/settings/appearance/appearance-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/appearance/appearance-es_ES.ts
+++ b/src/settings/appearance/appearance-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AppearanceSettings</name>
     <message>

--- a/src/settings/appearance/appearance-it_IT.ts
+++ b/src/settings/appearance/appearance-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AppearanceSettings</name>
     <message>

--- a/src/settings/appearance/appearance-pl_PL.ts
+++ b/src/settings/appearance/appearance-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AppearanceSettings</name>
     <message>

--- a/src/settings/appservices/appservices-cs_CZ.ts
+++ b/src/settings/appservices/appservices-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>AppDetails</name>
     <message>

--- a/src/settings/appservices/appservices-da_DK.ts
+++ b/src/settings/appservices/appservices-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AppDetails</name>
     <message>

--- a/src/settings/appservices/appservices-de_DE.ts
+++ b/src/settings/appservices/appservices-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AppDetails</name>
     <message>

--- a/src/settings/appservices/appservices-en_US.ts
+++ b/src/settings/appservices/appservices-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/appservices/appservices-es_ES.ts
+++ b/src/settings/appservices/appservices-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AppDetails</name>
     <message>

--- a/src/settings/appservices/appservices-it_IT.ts
+++ b/src/settings/appservices/appservices-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AppDetails</name>
     <message>

--- a/src/settings/appservices/appservices-pl_PL.ts
+++ b/src/settings/appservices/appservices-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AppDetails</name>
     <message>

--- a/src/settings/appservices/appservices-ru_RU.ts
+++ b/src/settings/appservices/appservices-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>AppDetails</name>
     <message>

--- a/src/settings/beaming/beaming-fr_FR.ts
+++ b/src/settings/beaming/beaming-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>Beaming</name>
     <message>

--- a/src/settings/beaming/beaming-it_IT.ts
+++ b/src/settings/beaming/beaming-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Beaming</name>
     <message>

--- a/src/settings/btsettings/btsettings-cs_CZ.ts
+++ b/src/settings/btsettings/btsettings-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>AudioDeviceConnectionStatus</name>
     <message>

--- a/src/settings/btsettings/btsettings-da_DK.ts
+++ b/src/settings/btsettings/btsettings-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AudioDeviceConnectionStatus</name>
     <message>

--- a/src/settings/btsettings/btsettings-de_DE.ts
+++ b/src/settings/btsettings/btsettings-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AudioDeviceConnectionStatus</name>
     <message>

--- a/src/settings/btsettings/btsettings-en_US.ts
+++ b/src/settings/btsettings/btsettings-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/btsettings/btsettings-es_ES.ts
+++ b/src/settings/btsettings/btsettings-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AudioDeviceConnectionStatus</name>
     <message>

--- a/src/settings/btsettings/btsettings-it_IT.ts
+++ b/src/settings/btsettings/btsettings-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AudioDeviceConnectionStatus</name>
     <message>

--- a/src/settings/btsettings/btsettings-pl_PL.ts
+++ b/src/settings/btsettings/btsettings-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AudioDeviceConnectionStatus</name>
     <message>

--- a/src/settings/callforwarding/callforwarding-da_DK.ts
+++ b/src/settings/callforwarding/callforwarding-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>CallClassTab</name>
     <message>

--- a/src/settings/callforwarding/callforwarding-de_DE.ts
+++ b/src/settings/callforwarding/callforwarding-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>CallClassTab</name>
     <message>

--- a/src/settings/callforwarding/callforwarding-en_US.ts
+++ b/src/settings/callforwarding/callforwarding-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/callforwarding/callforwarding-es_ES.ts
+++ b/src/settings/callforwarding/callforwarding-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>CallClassTab</name>
     <message>

--- a/src/settings/callforwarding/callforwarding-it_IT.ts
+++ b/src/settings/callforwarding/callforwarding-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>CallClassTab</name>
     <message>

--- a/src/settings/callforwarding/callforwarding-pl_PL.ts
+++ b/src/settings/callforwarding/callforwarding-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>CallClassTab</name>
     <message>

--- a/src/settings/gtalksettings/gtalksettings-cs_CZ.ts
+++ b/src/settings/gtalksettings/gtalksettings-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>GTalkSettings</name>
     <message>

--- a/src/settings/gtalksettings/gtalksettings-da_DK.ts
+++ b/src/settings/gtalksettings/gtalksettings-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>GTalkSettings</name>
     <message>

--- a/src/settings/gtalksettings/gtalksettings-de_DE.ts
+++ b/src/settings/gtalksettings/gtalksettings-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>GTalkSettings</name>
     <message>

--- a/src/settings/gtalksettings/gtalksettings-en_US.ts
+++ b/src/settings/gtalksettings/gtalksettings-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/gtalksettings/gtalksettings-es_ES.ts
+++ b/src/settings/gtalksettings/gtalksettings-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>GTalkSettings</name>
     <message>

--- a/src/settings/gtalksettings/gtalksettings-it_IT.ts
+++ b/src/settings/gtalksettings/gtalksettings-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>GTalkSettings</name>
     <message>

--- a/src/settings/gtalksettings/gtalksettings-pl_PL.ts
+++ b/src/settings/gtalksettings/gtalksettings-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>GTalkSettings</name>
     <message>

--- a/src/settings/gtalksettings/gtalksettings-ru_RU.ts
+++ b/src/settings/gtalksettings/gtalksettings-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>GTalkSettings</name>
     <message>

--- a/src/settings/handwriting/hwsettings-cs_CZ.ts
+++ b/src/settings/handwriting/hwsettings-cs_CZ.ts
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 <context>
     <name>CharSetDlg</name>
     <message>

--- a/src/settings/homescreen/homescreen-da_DK.ts
+++ b/src/settings/homescreen/homescreen-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>HomescreenSettings</name>
     <message>

--- a/src/settings/homescreen/homescreen-de_DE.ts
+++ b/src/settings/homescreen/homescreen-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>HomescreenSettings</name>
     <message>

--- a/src/settings/homescreen/homescreen-en_US.ts
+++ b/src/settings/homescreen/homescreen-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/homescreen/homescreen-es_ES.ts
+++ b/src/settings/homescreen/homescreen-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>HomescreenSettings</name>
     <message>

--- a/src/settings/homescreen/homescreen-fr_FR.ts
+++ b/src/settings/homescreen/homescreen-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>HomescreenSettings</name>
     <message>

--- a/src/settings/homescreen/homescreen-it_IT.ts
+++ b/src/settings/homescreen/homescreen-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>HomescreenSettings</name>
     <message>

--- a/src/settings/homescreen/homescreen-pl_PL.ts
+++ b/src/settings/homescreen/homescreen-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>HomescreenSettings</name>
     <message>

--- a/src/settings/hwsettings/hwsettings-cs_CZ.ts
+++ b/src/settings/hwsettings/hwsettings-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>CharSetDlg</name>
     <message>

--- a/src/settings/hwsettings/hwsettings-da_DK.ts
+++ b/src/settings/hwsettings/hwsettings-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>CharSetDlg</name>
     <message>

--- a/src/settings/hwsettings/hwsettings-de_DE.ts
+++ b/src/settings/hwsettings/hwsettings-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>CharSetDlg</name>
     <message>

--- a/src/settings/hwsettings/hwsettings-en_US.ts
+++ b/src/settings/hwsettings/hwsettings-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/hwsettings/hwsettings-es_ES.ts
+++ b/src/settings/hwsettings/hwsettings-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>CharSetDlg</name>
     <message>

--- a/src/settings/hwsettings/hwsettings-it_IT.ts
+++ b/src/settings/hwsettings/hwsettings-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>CharSetDlg</name>
     <message>

--- a/src/settings/hwsettings/hwsettings-pl_PL.ts
+++ b/src/settings/hwsettings/hwsettings-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>CharSetDlg</name>
     <message>

--- a/src/settings/hwsettings/hwsettings-ru_RU.ts
+++ b/src/settings/hwsettings/hwsettings-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>CharSetDlg</name>
     <message>

--- a/src/settings/language/language-da_DK.ts
+++ b/src/settings/language/language-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>LanguageSettings</name>
     <message>

--- a/src/settings/language/language-de_DE.ts
+++ b/src/settings/language/language-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>LanguageSettings</name>
     <message>

--- a/src/settings/language/language-en_US.ts
+++ b/src/settings/language/language-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/language/language-es_ES.ts
+++ b/src/settings/language/language-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>LanguageSettings</name>
     <message>

--- a/src/settings/language/language-it_IT.ts
+++ b/src/settings/language/language-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>LanguageSettings</name>
     <message>

--- a/src/settings/language/language-pl_PL.ts
+++ b/src/settings/language/language-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>LanguageSettings</name>
     <message>

--- a/src/settings/light-and-power/light-and-power-da_DK.ts
+++ b/src/settings/light-and-power/light-and-power-da_DK.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>LightSettings</name>
     <message>

--- a/src/settings/light-and-power/light-and-power-de_DE.ts
+++ b/src/settings/light-and-power/light-and-power-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>LightSettings</name>
     <message>

--- a/src/settings/light-and-power/light-and-power-en_US.ts
+++ b/src/settings/light-and-power/light-and-power-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/light-and-power/light-and-power-es_ES.ts
+++ b/src/settings/light-and-power/light-and-power-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>LightSettings</name>
     <message>

--- a/src/settings/light-and-power/light-and-power-it_IT.ts
+++ b/src/settings/light-and-power/light-and-power-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>LightSettings</name>
     <message>

--- a/src/settings/light-and-power/light-and-power-pl_PL.ts
+++ b/src/settings/light-and-power/light-and-power-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>LightSettings</name>
     <message>

--- a/src/settings/logging/logging-da_DK.ts
+++ b/src/settings/logging/logging-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>LoggingEdit</name>
     <message>

--- a/src/settings/logging/logging-de_DE.ts
+++ b/src/settings/logging/logging-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>LoggingEdit</name>
     <message>

--- a/src/settings/logging/logging-en_US.ts
+++ b/src/settings/logging/logging-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/logging/logging-es_ES.ts
+++ b/src/settings/logging/logging-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>LoggingEdit</name>
     <message>

--- a/src/settings/logging/logging-it_IT.ts
+++ b/src/settings/logging/logging-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>LoggingEdit</name>
     <message>

--- a/src/settings/logging/logging-pl_PL.ts
+++ b/src/settings/logging/logging-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>LoggingEdit</name>
     <message>

--- a/src/settings/netsetup/netsetup-cs_CZ.ts
+++ b/src/settings/netsetup/netsetup-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>AddNetworkUI</name>
     <message>

--- a/src/settings/netsetup/netsetup-da_DK.ts
+++ b/src/settings/netsetup/netsetup-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AddNetworkUI</name>
     <message>

--- a/src/settings/netsetup/netsetup-de_DE.ts
+++ b/src/settings/netsetup/netsetup-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AddNetworkUI</name>
     <message>

--- a/src/settings/netsetup/netsetup-en_US.ts
+++ b/src/settings/netsetup/netsetup-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/netsetup/netsetup-es_ES.ts
+++ b/src/settings/netsetup/netsetup-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AddNetworkUI</name>
     <message>

--- a/src/settings/netsetup/netsetup-it_IT.ts
+++ b/src/settings/netsetup/netsetup-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AddNetworkUI</name>
     <message>

--- a/src/settings/netsetup/netsetup-pl_PL.ts
+++ b/src/settings/netsetup/netsetup-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AddNetworkUI</name>
     <message>

--- a/src/settings/netsetup/netsetup-ru_RU.ts
+++ b/src/settings/netsetup/netsetup-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>AddNetworkUI</name>
     <message>

--- a/src/settings/network/netsetup-cs_CZ.ts
+++ b/src/settings/network/netsetup-cs_CZ.ts
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 <context>
     <name>AddNetworkUI</name>
     <message>

--- a/src/settings/packagemanager/packagemanager-cs_CZ.ts
+++ b/src/settings/packagemanager/packagemanager-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>AbstractPackageController</name>
     <message>

--- a/src/settings/packagemanager/packagemanager-da_DK.ts
+++ b/src/settings/packagemanager/packagemanager-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>AbstractPackageController</name>
     <message>

--- a/src/settings/packagemanager/packagemanager-de_DE.ts
+++ b/src/settings/packagemanager/packagemanager-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>AbstractPackageController</name>
     <message>

--- a/src/settings/packagemanager/packagemanager-en_US.ts
+++ b/src/settings/packagemanager/packagemanager-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>NetworkPackageController</name>
     <message numerus="yes">

--- a/src/settings/packagemanager/packagemanager-es_ES.ts
+++ b/src/settings/packagemanager/packagemanager-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>AbstractPackageController</name>
     <message>

--- a/src/settings/packagemanager/packagemanager-it_IT.ts
+++ b/src/settings/packagemanager/packagemanager-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>AbstractPackageController</name>
     <message>

--- a/src/settings/packagemanager/packagemanager-pl_PL.ts
+++ b/src/settings/packagemanager/packagemanager-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>AbstractPackageController</name>
     <message>

--- a/src/settings/phonenetworks/phonenetworks-da_DK.ts
+++ b/src/settings/phonenetworks/phonenetworks-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>ModemNetworkRegister</name>
     <message>

--- a/src/settings/phonenetworks/phonenetworks-de_DE.ts
+++ b/src/settings/phonenetworks/phonenetworks-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>ModemNetworkRegister</name>
     <message>

--- a/src/settings/phonenetworks/phonenetworks-en_US.ts
+++ b/src/settings/phonenetworks/phonenetworks-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/phonenetworks/phonenetworks-es_ES.ts
+++ b/src/settings/phonenetworks/phonenetworks-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>ModemNetworkRegister</name>
     <message>

--- a/src/settings/phonenetworks/phonenetworks-it_IT.ts
+++ b/src/settings/phonenetworks/phonenetworks-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>ModemNetworkRegister</name>
     <message>

--- a/src/settings/phonenetworks/phonenetworks-pl_PL.ts
+++ b/src/settings/phonenetworks/phonenetworks-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>ModemNetworkRegister</name>
     <message>

--- a/src/settings/phonesettings/phonesettings-cs_CZ.ts
+++ b/src/settings/phonesettings/phonesettings-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>CallBarring</name>
     <message>

--- a/src/settings/phonesettings/phonesettings-da_DK.ts
+++ b/src/settings/phonesettings/phonesettings-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>CallBarring</name>
     <message>

--- a/src/settings/phonesettings/phonesettings-de_DE.ts
+++ b/src/settings/phonesettings/phonesettings-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>CallBarring</name>
     <message>

--- a/src/settings/phonesettings/phonesettings-en_US.ts
+++ b/src/settings/phonesettings/phonesettings-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>FixedDialing</name>
     <message numerus="yes">

--- a/src/settings/phonesettings/phonesettings-es_ES.ts
+++ b/src/settings/phonesettings/phonesettings-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>CallBarring</name>
     <message>

--- a/src/settings/phonesettings/phonesettings-fr_FR.ts
+++ b/src/settings/phonesettings/phonesettings-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>CallBarring</name>
     <message>

--- a/src/settings/phonesettings/phonesettings-it_IT.ts
+++ b/src/settings/phonesettings/phonesettings-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>CallBarring</name>
     <message>

--- a/src/settings/phonesettings/phonesettings-pl_PL.ts
+++ b/src/settings/phonesettings/phonesettings-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>CallBarring</name>
     <message>

--- a/src/settings/profileedit/profileedit-cs_CZ.ts
+++ b/src/settings/profileedit/profileedit-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/profileedit/profileedit-da_DK.ts
+++ b/src/settings/profileedit/profileedit-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/profileedit/profileedit-de_DE.ts
+++ b/src/settings/profileedit/profileedit-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/profileedit/profileedit-en_US.ts
+++ b/src/settings/profileedit/profileedit-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/profileedit/profileedit-es_ES.ts
+++ b/src/settings/profileedit/profileedit-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/profileedit/profileedit-fr_FR.ts
+++ b/src/settings/profileedit/profileedit-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/profileedit/profileedit-it_IT.ts
+++ b/src/settings/profileedit/profileedit-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/profileedit/profileedit-pl_PL.ts
+++ b/src/settings/profileedit/profileedit-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/profileedit/profileedit-ru_RU.ts
+++ b/src/settings/profileedit/profileedit-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/ringprofile/profileedit-cs_CZ.ts
+++ b/src/settings/ringprofile/profileedit-cs_CZ.ts
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 <context>
     <name>ActiveProfileDisplay</name>
     <message>

--- a/src/settings/rotation/rotation-cs_CZ.ts
+++ b/src/settings/rotation/rotation-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>RotationSettings</name>
     <message>

--- a/src/settings/rotation/rotation-da_DK.ts
+++ b/src/settings/rotation/rotation-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>RotationSettings</name>
     <message>

--- a/src/settings/rotation/rotation-de_DE.ts
+++ b/src/settings/rotation/rotation-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>RotationSettings</name>
     <message>

--- a/src/settings/rotation/rotation-en_US.ts
+++ b/src/settings/rotation/rotation-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/rotation/rotation-es_ES.ts
+++ b/src/settings/rotation/rotation-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>RotationSettings</name>
     <message>

--- a/src/settings/rotation/rotation-it_IT.ts
+++ b/src/settings/rotation/rotation-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>RotationSettings</name>
     <message>

--- a/src/settings/rotation/rotation-pl_PL.ts
+++ b/src/settings/rotation/rotation-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>RotationSettings</name>
     <message>

--- a/src/settings/rotation/rotation-ru_RU.ts
+++ b/src/settings/rotation/rotation-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>RotationSettings</name>
     <message>

--- a/src/settings/security/security-da_DK.ts
+++ b/src/settings/security/security-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>Security</name>
     <message>

--- a/src/settings/security/security-de_DE.ts
+++ b/src/settings/security/security-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>Security</name>
     <message>

--- a/src/settings/security/security-en_US.ts
+++ b/src/settings/security/security-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/security/security-es_ES.ts
+++ b/src/settings/security/security-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Security</name>
     <message>

--- a/src/settings/security/security-it_IT.ts
+++ b/src/settings/security/security-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Security</name>
     <message>

--- a/src/settings/security/security-pl_PL.ts
+++ b/src/settings/security/security-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>Security</name>
     <message>

--- a/src/settings/serverwidgets/serverwidgets-fr_FR.ts
+++ b/src/settings/serverwidgets/serverwidgets-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>QObject</name>
     <message>

--- a/src/settings/serverwidgets/serverwidgets-it_IT.ts
+++ b/src/settings/serverwidgets/serverwidgets-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QObject</name>
     <message>

--- a/src/settings/sipsettings/sipsettings-cs_CZ.ts
+++ b/src/settings/sipsettings/sipsettings-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>SipSettings</name>
     <message>

--- a/src/settings/sipsettings/sipsettings-da_DK.ts
+++ b/src/settings/sipsettings/sipsettings-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>SipSettings</name>
     <message>

--- a/src/settings/sipsettings/sipsettings-de_DE.ts
+++ b/src/settings/sipsettings/sipsettings-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>SipSettings</name>
     <message>

--- a/src/settings/sipsettings/sipsettings-en_US.ts
+++ b/src/settings/sipsettings/sipsettings-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/sipsettings/sipsettings-es_ES.ts
+++ b/src/settings/sipsettings/sipsettings-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>SipSettings</name>
     <message>

--- a/src/settings/sipsettings/sipsettings-it_IT.ts
+++ b/src/settings/sipsettings/sipsettings-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>SipSettings</name>
     <message>

--- a/src/settings/sipsettings/sipsettings-pl_PL.ts
+++ b/src/settings/sipsettings/sipsettings-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>SipSettings</name>
     <message>

--- a/src/settings/sipsettings/sipsettings-ru_RU.ts
+++ b/src/settings/sipsettings/sipsettings-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>SipSettings</name>
     <message>

--- a/src/settings/speeddial/speeddial-da_DK.ts
+++ b/src/settings/speeddial/speeddial-da_DK.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>QSpeedDialEdit</name>
     <message>

--- a/src/settings/speeddial/speeddial-de_DE.ts
+++ b/src/settings/speeddial/speeddial-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>QSpeedDialEdit</name>
     <message>

--- a/src/settings/speeddial/speeddial-en_US.ts
+++ b/src/settings/speeddial/speeddial-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/speeddial/speeddial-es_ES.ts
+++ b/src/settings/speeddial/speeddial-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>QSpeedDialEdit</name>
     <message>

--- a/src/settings/speeddial/speeddial-it_IT.ts
+++ b/src/settings/speeddial/speeddial-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QSpeedDialEdit</name>
     <message>

--- a/src/settings/speeddial/speeddial-pl_PL.ts
+++ b/src/settings/speeddial/speeddial-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>QSpeedDialEdit</name>
     <message>

--- a/src/settings/startupflags/startupflags-cs_CZ.ts
+++ b/src/settings/startupflags/startupflags-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>StartupFlags</name>
     <message>

--- a/src/settings/startupflags/startupflags-da_DK.ts
+++ b/src/settings/startupflags/startupflags-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>StartupFlags</name>
     <message>

--- a/src/settings/startupflags/startupflags-de_DE.ts
+++ b/src/settings/startupflags/startupflags-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>StartupFlags</name>
     <message>

--- a/src/settings/startupflags/startupflags-en_US.ts
+++ b/src/settings/startupflags/startupflags-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/startupflags/startupflags-es_ES.ts
+++ b/src/settings/startupflags/startupflags-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>StartupFlags</name>
     <message>

--- a/src/settings/startupflags/startupflags-it_IT.ts
+++ b/src/settings/startupflags/startupflags-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>StartupFlags</name>
     <message>

--- a/src/settings/startupflags/startupflags-pl_PL.ts
+++ b/src/settings/startupflags/startupflags-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>StartupFlags</name>
     <message>

--- a/src/settings/startupflags/startupflags-ru_RU.ts
+++ b/src/settings/startupflags/startupflags-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>StartupFlags</name>
     <message>

--- a/src/settings/systemtime/systemtime-da_DK.ts
+++ b/src/settings/systemtime/systemtime-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>SetDateTime</name>
     <message>

--- a/src/settings/systemtime/systemtime-de_DE.ts
+++ b/src/settings/systemtime/systemtime-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>SetDateTime</name>
     <message>

--- a/src/settings/systemtime/systemtime-en_US.ts
+++ b/src/settings/systemtime/systemtime-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/systemtime/systemtime-es_ES.ts
+++ b/src/settings/systemtime/systemtime-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>SetDateTime</name>
     <message>

--- a/src/settings/systemtime/systemtime-it_IT.ts
+++ b/src/settings/systemtime/systemtime-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>SetDateTime</name>
     <message>

--- a/src/settings/systemtime/systemtime-pl_PL.ts
+++ b/src/settings/systemtime/systemtime-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>SetDateTime</name>
     <message>

--- a/src/settings/words/words-da_DK.ts
+++ b/src/settings/words/words-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>Words</name>
     <message>

--- a/src/settings/words/words-de_DE.ts
+++ b/src/settings/words/words-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>Words</name>
     <message>

--- a/src/settings/words/words-en_US.ts
+++ b/src/settings/words/words-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/words/words-es_ES.ts
+++ b/src/settings/words/words-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>Words</name>
     <message>

--- a/src/settings/words/words-it_IT.ts
+++ b/src/settings/words/words-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>Words</name>
     <message>

--- a/src/settings/words/words-pl_PL.ts
+++ b/src/settings/words/words-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>Words</name>
     <message>

--- a/src/settings/worldtime/worldtime-da_DK.ts
+++ b/src/settings/worldtime/worldtime-da_DK.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
   <context><name>WorldTime</name><message>
         <location filename="worldtime.cpp" line="57"/>
         <location filename="worldtime.cpp" line="225"/>

--- a/src/settings/worldtime/worldtime-de_DE.ts
+++ b/src/settings/worldtime/worldtime-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>WorldTime</name>
     <message>

--- a/src/settings/worldtime/worldtime-en_US.ts
+++ b/src/settings/worldtime/worldtime-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/settings/worldtime/worldtime-es_ES.ts
+++ b/src/settings/worldtime/worldtime-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>WorldTime</name>
     <message>

--- a/src/settings/worldtime/worldtime-it_IT.ts
+++ b/src/settings/worldtime/worldtime-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>WorldTime</name>
     <message>

--- a/src/settings/worldtime/worldtime-pl_PL.ts
+++ b/src/settings/worldtime/worldtime-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>WorldTime</name>
     <message>

--- a/src/tools/dbmigrate/libdbmigrate-cs_CZ.ts
+++ b/src/tools/dbmigrate/libdbmigrate-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>QObject</name>
     <message>

--- a/src/tools/dbmigrate/libdbmigrate-da_DK.ts
+++ b/src/tools/dbmigrate/libdbmigrate-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>QObject</name>
     <message>

--- a/src/tools/dbmigrate/libdbmigrate-de_DE.ts
+++ b/src/tools/dbmigrate/libdbmigrate-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>QObject</name>
     <message>

--- a/src/tools/dbmigrate/libdbmigrate-en_US.ts
+++ b/src/tools/dbmigrate/libdbmigrate-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/tools/dbmigrate/libdbmigrate-es_ES.ts
+++ b/src/tools/dbmigrate/libdbmigrate-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>QObject</name>
     <message>

--- a/src/tools/dbmigrate/libdbmigrate-it_IT.ts
+++ b/src/tools/dbmigrate/libdbmigrate-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QObject</name>
     <message>

--- a/src/tools/dbmigrate/libdbmigrate-pl_PL.ts
+++ b/src/tools/dbmigrate/libdbmigrate-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>QObject</name>
     <message>

--- a/src/tools/dbmigrate/libdbmigrate-ru_RU.ts
+++ b/src/tools/dbmigrate/libdbmigrate-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>QObject</name>
     <message>

--- a/src/tools/device_updater/plugin/libdevice_updater-cs_CZ.ts
+++ b/src/tools/device_updater/plugin/libdevice_updater-cs_CZ.ts
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 </TS>

--- a/src/tools/device_updater/plugin/libdevice_updater-ru_RU.ts
+++ b/src/tools/device_updater/plugin/libdevice_updater-ru_RU.ts
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="ru_RU">
 </TS>

--- a/src/tools/mediaserver/mediaserver-cs_CZ.ts
+++ b/src/tools/mediaserver/mediaserver-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>mediaserver::QtopiaMediaProvider</name>
     <message>

--- a/src/tools/mediaserver/mediaserver-da_DK.ts
+++ b/src/tools/mediaserver/mediaserver-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>mediaserver::QtopiaMediaProvider</name>
     <message>

--- a/src/tools/mediaserver/mediaserver-de_DE.ts
+++ b/src/tools/mediaserver/mediaserver-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>mediaserver::QtopiaMediaProvider</name>
     <message>

--- a/src/tools/mediaserver/mediaserver-en_US.ts
+++ b/src/tools/mediaserver/mediaserver-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/tools/mediaserver/mediaserver-es_ES.ts
+++ b/src/tools/mediaserver/mediaserver-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>mediaserver::QtopiaMediaProvider</name>
     <message>

--- a/src/tools/mediaserver/mediaserver-it_IT.ts
+++ b/src/tools/mediaserver/mediaserver-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>mediaserver::QtopiaMediaProvider</name>
     <message>

--- a/src/tools/mediaserver/mediaserver-pl_PL.ts
+++ b/src/tools/mediaserver/mediaserver-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>mediaserver::QtopiaMediaProvider</name>
     <message>

--- a/src/tools/messageserver/messageserver-cs_CZ.ts
+++ b/src/tools/messageserver/messageserver-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>CollectiveClient</name>
     <message>

--- a/src/tools/messageserver/messageserver-da_DK.ts
+++ b/src/tools/messageserver/messageserver-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>CollectiveClient</name>
     <message>

--- a/src/tools/messageserver/messageserver-de_DE.ts
+++ b/src/tools/messageserver/messageserver-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>CollectiveClient</name>
     <message>

--- a/src/tools/messageserver/messageserver-en_US.ts
+++ b/src/tools/messageserver/messageserver-en_US.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 <context>
     <name>SmtpClient</name>
     <message numerus="yes">

--- a/src/tools/messageserver/messageserver-es_ES.ts
+++ b/src/tools/messageserver/messageserver-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>CollectiveClient</name>
     <message>

--- a/src/tools/messageserver/messageserver-it_IT.ts
+++ b/src/tools/messageserver/messageserver-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>CollectiveClient</name>
     <message>

--- a/src/tools/messageserver/messageserver-pl_PL.ts
+++ b/src/tools/messageserver/messageserver-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>CollectiveClient</name>
     <message>

--- a/src/tools/messageserver/messageserver-ru_RU.ts
+++ b/src/tools/messageserver/messageserver-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>CollectiveClient</name>
     <message>

--- a/src/tools/printserver/printserver-cs_CZ.ts
+++ b/src/tools/printserver/printserver-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>PrintServer</name>
     <message>

--- a/src/tools/printserver/printserver-da_DK.ts
+++ b/src/tools/printserver/printserver-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>PrintServer</name>
     <message>

--- a/src/tools/printserver/printserver-de_DE.ts
+++ b/src/tools/printserver/printserver-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>PrintServer</name>
     <message>

--- a/src/tools/printserver/printserver-en_US.ts
+++ b/src/tools/printserver/printserver-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/tools/printserver/printserver-es_ES.ts
+++ b/src/tools/printserver/printserver-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>PrintServer</name>
     <message>

--- a/src/tools/printserver/printserver-fr_FR.ts
+++ b/src/tools/printserver/printserver-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>PrintServer</name>
     <message>

--- a/src/tools/printserver/printserver-it_IT.ts
+++ b/src/tools/printserver/printserver-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>PrintServer</name>
     <message>

--- a/src/tools/printserver/printserver-pl_PL.ts
+++ b/src/tools/printserver/printserver-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>PrintServer</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-cs_CZ.ts
+++ b/src/tools/qdsync/app/qdsync-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-da_DK.ts
+++ b/src/tools/qdsync/app/qdsync-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-de_DE.ts
+++ b/src/tools/qdsync/app/qdsync-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-en_US.ts
+++ b/src/tools/qdsync/app/qdsync-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/tools/qdsync/app/qdsync-es_ES.ts
+++ b/src/tools/qdsync/app/qdsync-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-fr_FR.ts
+++ b/src/tools/qdsync/app/qdsync-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-it_IT.ts
+++ b/src/tools/qdsync/app/qdsync-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-nct-cs_CZ.ts
+++ b/src/tools/qdsync/app/qdsync-nct-cs_CZ.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="cs_CZ">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-nct-da_DK.ts
+++ b/src/tools/qdsync/app/qdsync-nct-da_DK.ts
@@ -1,5 +1,5 @@
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="da_DK">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-nct-de_DE.ts
+++ b/src/tools/qdsync/app/qdsync-nct-de_DE.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="de_DE">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-nct-en_US.ts
+++ b/src/tools/qdsync/app/qdsync-nct-en_US.ts
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="en_US">
 </TS>

--- a/src/tools/qdsync/app/qdsync-nct-es_ES.ts
+++ b/src/tools/qdsync/app/qdsync-nct-es_ES.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="es_ES">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-nct-fr_FR.ts
+++ b/src/tools/qdsync/app/qdsync-nct-fr_FR.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="fr_FR">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-nct-it_IT.ts
+++ b/src/tools/qdsync/app/qdsync-nct-it_IT.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="it_IT">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-nct-pl_PL.ts
+++ b/src/tools/qdsync/app/qdsync-nct-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-nct-ru_RU.ts
+++ b/src/tools/qdsync/app/qdsync-nct-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-pl_PL.ts
+++ b/src/tools/qdsync/app/qdsync-pl_PL.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="pl_PL">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/qdsync/app/qdsync-ru_RU.ts
+++ b/src/tools/qdsync/app/qdsync-ru_RU.ts
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.0">
+<TS version="2.0" language="ru_RU">
 <context>
     <name>QDSync</name>
     <message>

--- a/src/tools/startupflags/startupflags-cs_CZ.ts
+++ b/src/tools/startupflags/startupflags-cs_CZ.ts
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!DOCTYPE TS><TS version="1.1">
+<!DOCTYPE TS><TS version="1.1" language="cs_CZ">
 <context>
     <name>StartupFlags</name>
     <message>


### PR DESCRIPTION
Most translation files are b0rked, as shown by "qbuild lupdate" dropping plurals for danish, which was virtually the only language with translated plurals.

This allows for what is currently in my i18n branch, but which I do no submit yet since the resulting .qm files are completely untested - but I don't expect large bugs any more in that branch, and you may want to test it yourself.
