### PR TITLE
Add "ntpdate" to debian package dependencies.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Package: qtmoko-neo
 Provides: qtmoko
 Conflicts: qtmoko
 Architecture: armel
-Depends: ${misc:Depends}, ${shlibs:Depends}, bluez-alsa, ttf-dejavu, sqlite3, psmisc, alsa-utils
+Depends: ${misc:Depends}, ${shlibs:Depends}, bluez-alsa, ttf-dejavu, sqlite3, psmisc, alsa-utils, ntpdate
 Description: Smartphone environment based on QT Extended - Neo FreeRunner flavor
  QtMoko provides a fully integrated phone stack plus smartphone environment
  for Linux based smartphones.


### PR DESCRIPTION
qtmoko has ntpdate support, but could just not use it:

Jan  6 16:34:09 neo Qtopia: Network seems present. Update time using ntp
Jan  6 16:34:09 neo Qtopia: timeout: failed to run command `ntpdate': No such file or directory
