### PR TITLE
Let qpe.sh kill atd, for devices that run it (issue #74).

### DIFF
--- a/devices/gta04/src/devtools/startup/qpe.sh
+++ b/devices/gta04/src/devtools/startup/qpe.sh
@@ -25,9 +25,12 @@ echo 0 > /sys/class/leds/gta04\:red\:power/brightness
 echo 0 > /sys/class/leds/gta04\:green\:power/brightness
 stty -F /dev/tty1 -echo
 mkdir -p /var/cache/apt/archives/partial
+
 atd /var/spool/at
 
 touch /tmp/restart-qtopia
 while [ -e /tmp/restart-qtopia ]; do
 qpe 2>&1 | logger -t 'Qtopia'
 done
+
+killall -q atd

--- a/devices/neo/src/devtools/startup/qpe.sh
+++ b/devices/neo/src/devtools/startup/qpe.sh
@@ -15,6 +15,7 @@ stty -F /dev/tty1 -echo
 rm -rf /var/run/ppp
 mkdir /var/run/ppp
 mkdir -p /var/cache/apt/archives/partial
+
 atd /var/spool/at
 
 touch /tmp/restart-qtopia
@@ -29,3 +30,5 @@ if [ -e /tmp/restart-qtopia-qvga ]; then
     #qcop service send Launcher "execute(QString)" "calibrate"
 fi
 done
+
+killall -q atd


### PR DESCRIPTION
If we let the init.d stop action do that, the "shutdown" button in the GUI
will not terminate it.
