### PR TITLE
Assorted fixes

### DIFF
--- a/debian/README.source
+++ b/debian/README.source
@@ -2,14 +2,15 @@ Cross-building QtMoko on Debian
 -------------------------------
 
 It is possible to cross-build QtMoko on a Debian box using the emdebian
-tooltoolchain. The build is run the Debian way, using pbuilder on a Debian
-Wheezy or sid box. Most of the magic is handled by the pdebuild-cross package:
+toolchain. The build is run the Debian way, using pbuilder on a Debian
+wheezy or sid box. Most of the magic is handled by the pdebuild-cross package:
 
 $ sudo apt-get install pdebuild-cross
 
-The toolchain is set up via the multistrap package (pulled in by pdebuild-cross).
+The cross-build environement and toolchain are set up via the
+multistrap package (pulled in by pdebuild-cross).
 
-multistrap configuration file:
+multistrap configuration file (eg. /etc/pdebuild-cross/multistrap-qtmoko.conf):
 # ---%<--begin---
 [General]
 arch=
@@ -29,27 +30,34 @@ unpack=true
 omitrequired=false
 configscript=
 setupscript=/usr/share/multistrap/setcrossarch.sh
-debootstrap=Debian Toolchains
-aptsources=Debian Toolchains
+debootstrap=Debian Toolchains Backports
+aptsources=Debian
 tarballname=pdebuild-cross.tgz
 
 [Toolchains]
-packages=g++-4.4-arm-linux-gnueabi
+packages=g++-4.3-arm-linux-gnueabi
 reinstall=binutils-multiarch
 source=http://www.emdebian.org/debian
 keyring=emdebian-archive-keyring
 suite=testing
+omitdebsrc=true
+
+[Backports]
+packages=xapt
+source=http://backports.debian.org/debian-backports
+keyring=debian-archive-keyring
+suite=squeeze-backports
+omitdebsrc=true
 
 [Debian]
-packages=dpkg-dev binutils-multiarch build-essential makedev
-# Choose your preferred mirror
-source=http://ftp.fr.debian.org/debian
+packages=dpkg-dev binutils-multiarch build-essential makedev libdpkg-perl
+source=http://cdn.debian.net/debian
 keyring=debian-archive-keyring
-suite=unstable
-omitdebsrc=false
+suite=squeeze
+omitdebsrc=true
 # ---%<--end-----
 
-pdebuild-cross configuration file:
+pdebuild-cross configuration file (/etc/pdebuild-cross/pdebuild-cross.rc):
 # ---%<--begin---
 # this is your configuration file for pdebuild-cross.
 # /etc/pdebuild-cross/pdebuild-cross.rc is the one meant for editing.
@@ -61,9 +69,8 @@ pdebuild-cross configuration file:
 
 CROSSARCH=armel
 DEBBUILDOPTS="-aarmel"
-MULTISTRAPFILE=<path the the multistrap configuration file>
-#BASETGZ=/var/lib/pdebuild-cross/pdebuild-cross.tgz
-BASETGZ=/home/pdebuild-cross.tgz
+MULTISTRAPFILE=/etc/pdebuild-cross/multistrap-qtmoko.conf
+BASETGZ=/var/lib/pdebuild-cross/pdebuild-cross.tgz
 BUILDPLACE=/var/lib/pdebuild-cross/build/
 BUILDRESULT=..
 APTCACHE=/var/lib/pdebuild-cross/aptcache/
@@ -84,15 +91,12 @@ Create the pbuilder chroot:
 $ sudo pdebuild-cross-create
 $ sudo pdebuild-cross-update
 
-Create the orig.tar.gz archive:
-
-$ tar czf ../qtmoko_<release>.orig.tar.gz -C .. --exclude .git --exclude .pc --exclude qtmoko/debian --transform 's:\./qtmoko:qtmoko-<release>:' ./qtmoko
-
 Build:
 
 $ pdebuild-cross -aarmel
 
 On my amd64 box the whole build takes about five hours.
 
+ -- Yann Dirson <dirson@debian.org>, Sun, 29 Apr 2012 18:25:22 +0200
 
  -- Gilles Filippini <gilles.filippini@free.fr>  Sun, 11 Dec 2011 13:54:05 +0100

--- a/debian/control.in
+++ b/debian/control.in
@@ -12,7 +12,7 @@ Package: qtmoko-@QTMOKO_DEVICE@
 Provides: qtmoko
 Conflicts: qtmoko
 Architecture: armel
-Depends: ${misc:Depends}, ${shlibs:Depends}, bluez-alsa, ttf-dejavu, sqlite3, psmisc, alsa-utils
+Depends: ${misc:Depends}, ${shlibs:Depends}, bluez-alsa, ttf-dejavu, sqlite3, psmisc, alsa-utils, ntpdate
 Description: Smartphone environment based on QT Extended - @QTMOKO_DEVICE_SHORTDESC@ flavor
  QtMoko provides a fully integrated phone stack plus smartphone environment
  for Linux based smartphones.

--- a/src/build/bin/configure
+++ b/src/build/bin/configure
@@ -2109,10 +2109,10 @@ if ( opt("qtopia_ui") ) {
 opt("platform", "absolute") = fixpath(opt("platform", "absolute"));
 opt("xplatform", "absolute") = fixpath(opt("xplatform", "absolute"));
 if ( ! -e opt("platform", "absolute") ) {
-    die "ERROR: ".fixpath(opt("platform", "absolute"))." does not exist, check -platform parameter is correct.\n";
+    die "ERROR: ".opt("platform", "absolute")." does not exist, check -platform parameter is correct.\n";
 }
 if ( opt("qtopia_ui") && ! -e opt("xplatform", "absolute") ) {
-    die "ERROR: ".fixpath(opt("xplatform", "absolute"))." does not exist, check -xplatform parameter is correct.\n";
+    die "ERROR: ".opt("xplatform", "absolute")." does not exist, check -xplatform parameter is correct.\n";
 }
 # When building the SDK we want to create the 'default' mkspecs... we need a path
 # relative to the install prefix for that...

--- a/src/plugins/inputmethods/biglandscapekeyboard/keyboard.h
+++ b/src/plugins/inputmethods/biglandscapekeyboard/keyboard.h
@@ -67,7 +67,6 @@ public:
 
     QWidget* frame();
     void resetState();
-    QAction* menuActionToDuplicate(){ return mAction;};
     void menuActionActivated(int v);
 
 signals:
@@ -82,7 +81,6 @@ protected:
     KeyboardFrame *keyboardFrame;
     int microX;
     int microY;
-    QAction* mAction;
 };
 
 #endif

--- a/src/plugins/inputmethods/biglandscapekeyboard/keyboardimpl.cpp
+++ b/src/plugins/inputmethods/biglandscapekeyboard/keyboardimpl.cpp
@@ -81,13 +81,13 @@ QIcon KeyboardInputMethod::icon() const
 
 QString KeyboardInputMethod::name() const
 {
-    return qApp->translate( "InputMethods", "Keyboard" );
+    return qApp->translate( "InputMethods", "LandscapeKeyboard" );
 //    return qApp->translate( "InputMethods", "Opti" );
 }
 
 QString KeyboardInputMethod::identifier() const
 {
-    return "Keyboard";
+    return "LandscapeKeyboard";
 }
 
 QString KeyboardInputMethod::version() const

--- a/src/plugins/inputmethods/biglandscapekeyboard/keyboardimpl.cpp
+++ b/src/plugins/inputmethods/biglandscapekeyboard/keyboardimpl.cpp
@@ -54,8 +54,6 @@ KeyboardInputMethod::KeyboardInputMethod(QObject *parent)
 KeyboardInputMethod::~KeyboardInputMethod()
 {
     delete input;
-    while(!keyboardActionDescriptionList.isEmpty())
-        delete keyboardActionDescriptionList.takeLast();
 }
 
 QWidget *KeyboardInputMethod::inputWidget( QWidget *parent )

--- a/src/plugins/inputmethods/biglandscapekeyboard/keyboardimpl.h
+++ b/src/plugins/inputmethods/biglandscapekeyboard/keyboardimpl.h
@@ -53,7 +53,6 @@ private slots:
     void sendKeyPress( ushort unicode, ushort keycode, ushort modifiers, bool press, bool repeat );
 private:
     Keyboard *input;
-    QList<QIMActionDescription*> keyboardActionDescriptionList;
     void queryResponse ( int property, const QVariant & result );
 };
 

--- a/src/server/phone/telephony/callpolicymanager/cell/cellmodemmanager.cpp
+++ b/src/server/phone/telephony/callpolicymanager/cell/cellmodemmanager.cpp
@@ -41,12 +41,12 @@ class CellModemManagerPrivate
 public:
     CellModemManagerPrivate()
     : m_state(CellModemManager::Initializing),
-      m_netReg(0), m_aerialOn(false), m_aerialStable(false),
-      m_pinManager(0), m_regState(QTelephony::RegistrationNone),
-      m_status(0), m_autoRegisterTimer(0), m_profiles(0),
-      m_profilesBlocked(false), m_callForwarding(0),
+      m_netReg(NULL), m_aerialOn(false), m_aerialStable(false),
+      m_pinManager(NULL), m_regState(QTelephony::RegistrationNone),
+      m_status(NULL), m_autoRegisterTimer(NULL), m_profiles(NULL),
+      m_profilesBlocked(false), m_callForwarding(NULL),
       m_callForwardingEnabled(false),
-      m_rfFunc(0), m_phoneBook(0) {}
+      m_rfFunc(NULL), m_phoneBook(NULL) {}
 
     CellModemManager::State m_state;
     QNetworkRegistration *m_netReg;


### PR DESCRIPTION
All but the README.source patch are trivial, if I can say such a silly thing :)

Note that while I had a couple of other patches applied above v44 when testing the cross-build packaging (mostly, i18n fixes that surely all justify the additional files), the resulting deb had the following debdiff with the official v44, showing that you were probably building with an older version of squeeze.

I am a bit concerned about the additional 4MB - the additional translations cannot account for that. If you have used g++-4.4, however, we could have the explanation...

$ debdiff qtmoko-neo_44-1_armel.deb qtmoko-neo_44yd-0_armel.deb |less
[The following lists of changes regard files as different if they have
different names, permissions or owners.]
## Files in second .deb but not in first

-rw-r--r--  root/root   /opt/qtmoko/i18n/cs_CZ/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/cs_CZ/startupflags.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/da_DK/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/da_DK/startupflags.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/de_DE/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/de_DE/startupflags.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/en_US/gta02-gps.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/en_US/gta02-gsm-bt-fix.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/en_US/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/en_US/startupflags.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/es_ES/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/es_ES/startupflags.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/fr_FR/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/fr_FR/startupflags.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/it_IT/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/it_IT/startupflags.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/pl_PL/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/pl_PL/startupflags.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/ru_RU/raptor.qm
-rw-r--r--  root/root   /opt/qtmoko/i18n/ru_RU/startupflags.qm
## Control files: lines which differ (wdiff format)

Depends: libasound2 (>> 1.0.18), libc6 (>= [-2.7),-] {+2.11),+} libdbus-1-3 (>= [-1.0.2), libgcc1 (>= 1:4.4.0),-] {+1.2.16), libgcc1,+} libjpeg62 (>= 6b1), libmng1 (>= [-1.0.10),-] {+1.0.3-1),+} libpng12-0 (>= 1.2.13-4), [-libstdc++6 (>= 4.4.0),-] {+libstdc++6,+} libtiff4, [-libts-0.0-0 (>= 1.0),-] {+libts-0.0-0,+} libx11-6, libxtst6, zlib1g (>= [-1:1.1.4),-] {+1:1.2.3.3.dfsg-1),+} bluez-alsa, ttf-dejavu, sqlite3, psmisc, [-alsa-utils-] {+alsa-utils, ntpdate+}
Installed-Size: [-66092-] {+70488+}
Version: [-44-1-] {+44yd-0+}
