### PR TITLE
Do not spend CPU cycles for building host Qt, build-depend on libqt4-dev...

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qtmoko
 Section: comm
 Priority: optional
 Maintainer: Radek Polak <psonek2@seznam.cz>
-Build-Depends: debhelper (>= 7.0.50~), libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg62-dev, libtiff4-dev, libmng-dev
+Build-Depends: debhelper (>= 7.0.50~), libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg62-dev, libtiff4-dev, libmng-dev, libqt4-dev
 Standards-Version: 3.9.2
 Homepage: http://www.qtmoko.org
 Vcs-Git: git://github.com/radekp/qtmoko.git

--- a/debian/control.in
+++ b/debian/control.in
@@ -2,7 +2,7 @@ Source: qtmoko
 Section: comm
 Priority: optional
 Maintainer: Radek Polak <psonek2@seznam.cz>
-Build-Depends: debhelper (>= 7.0.50~), libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg62-dev, libtiff4-dev, libmng-dev
+Build-Depends: debhelper (>= 7.0.50~), libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg62-dev, libtiff4-dev, libmng-dev, libqt4-dev, libqt4-sql-sqlite
 Standards-Version: 3.9.2
 Homepage: http://www.qtmoko.org
 Vcs-Git: git://github.com/radekp/qtmoko.git

--- a/debian/rules
+++ b/debian/rules
@@ -88,7 +88,7 @@ override_dh_auto_clean:
 override_dh_auto_install:
 	$(MAKE) -C ../build install
 	mkdir -p debian/tmp/opt/qtmoko
-	cp -r ../build/image/* debian/tmp/opt/qtmoko
+	cp -al ../build/image/* debian/tmp/opt/qtmoko/
 
 	# remove patented stuff - can be installed via package later
 	rm -f debian/tmp/opt/qtmoko/plugins/codecs/libmadplugin.so

--- a/debian/rules
+++ b/debian/rules
@@ -72,7 +72,7 @@ override_dh_auto_configure:
 	cd ../build && "$(CONFIGURE)" -device $(QTMOKO_DEVICE) -force-build-qt -xplatform $(TOOLCHAIN) -remove-module pkgmanagement -languages $(LANGUAGES) -l dbus-1 -I /usr/include/dbus-1.0/ -I /usr/lib/dbus-1.0/include
 
 override_dh_auto_build:
-	cd ../build && make
+	$(MAKE) -C ../build
 
 override_dh_auto_clean:
 	[ ! -f $(QMAKE_CONF).orig ] || mv $(QMAKE_CONF).orig $(QMAKE_CONF)
@@ -86,7 +86,7 @@ override_dh_auto_clean:
 	rm -f debian/qtmoko-*.init
 
 override_dh_auto_install:
-	cd ../build && make install
+	$(MAKE) -C ../build install
 	mkdir -p debian/tmp/opt/qtmoko
 	cp -r ../build/image/* debian/tmp/opt/qtmoko
 
@@ -98,7 +98,7 @@ override_dh_auto_install:
 	rm -rf debian/tmp/opt/qtmoko/lib/fonts
 
 	# Install missing dependency for qt_plugins/script/libqtscriptdbus.so
-	install -m"a+r,u+w" ../build/qtopiacore/target/lib/libQtScript.so.4.5.3 debian/tmp/opt/qtmoko/lib
+	install -m"a+r,u+w" ../build/qtopiacore/target/lib/libQtScript.so.4.5.3 debian/tmp/opt/qtmoko/lib/
 
 override_dh_makeshlibs:
 	dh_makeshlibs -n

--- a/debian/rules
+++ b/debian/rules
@@ -69,7 +69,7 @@ override_dh_auto_configure:
 
 	# Qt Extended configuration step
 	mkdir -p ../build
-	cd ../build && "$(CONFIGURE)" -device $(QTMOKO_DEVICE) -force-build-qt -xplatform $(TOOLCHAIN) -remove-module pkgmanagement -languages $(LANGUAGES) -l dbus-1 -I /usr/include/dbus-1.0/ -I /usr/lib/dbus-1.0/include
+	cd ../build && "$(CONFIGURE)" -device $(QTMOKO_DEVICE) -system-qt -xplatform $(TOOLCHAIN) -remove-module pkgmanagement -languages $(LANGUAGES) -l dbus-1 -I /usr/include/dbus-1.0/ -I /usr/lib/dbus-1.0/include
 
 override_dh_auto_build:
 	$(MAKE) -C ../build

--- a/qbuild/src/solution.cpp
+++ b/qbuild/src/solution.cpp
@@ -448,7 +448,8 @@ SolutionFile SolutionFile::canonicalPath() const
     SolutionFile ret = (*this);
     QFileInfo file_info = QFileInfo(m_path);
     QString dir = file_info.canonicalPath();
-    if ( !dir.isEmpty() ) {
+    //if ( !dir.isEmpty() ) {
+    if ( !dir.isEmpty() && (dir != ".") ) { // see https://bugreports.qt-project.org/browse/QTBUG-25537
         ret.m_path = dir+"/"+file_info.fileName();
         ret.m_request = solution()->fuzzyRealToSolution(ret.m_path).m_request;
     }


### PR DESCRIPTION
This has the nice side-effect to work around github issue #110.

I know that you currently prefer to rebuild a new (old) native qt instead of using the debian-compiled one in your qemu image, so I used a different branch than for the other fixes, in case you'd wish to persist with this strange idea :)
