### PR TITLE
Support for Qt 4.8.x

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qtmoko
 Section: comm
 Priority: optional
 Maintainer: Radek Polak <psonek2@seznam.cz>
-Build-Depends: debhelper (>= 7.0.50~), libqt4-dev, libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg8-dev, libv4l-dev, libqt4-sql-sqlite, libspeexdsp-dev, libsqlite3-dev
+Build-Depends: debhelper (>= 7.0.50~), libqt4-dev, libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg8-dev, libv4l-dev, libqt4-sql-sqlite, libspeexdsp-dev, libglib2.0-dev, libsqlite3-dev, quilt
 Standards-Version: 3.9.2
 Homepage: http://www.qtmoko.org
 Vcs-Git: git://github.com/radekp/qtmoko.git

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: qtmoko
 Section: comm
 Priority: optional
 Maintainer: Radek Polak <psonek2@seznam.cz>
-Build-Depends: debhelper (>= 7.0.50~), libqt4-dev, libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg8-dev, libv4l-dev, libqt4-sql-sqlite, libspeexdsp-dev
+Build-Depends: debhelper (>= 7.0.50~), libqt4-dev, libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg8-dev, libv4l-dev, libqt4-sql-sqlite, libspeexdsp-dev, libsqlite3-dev
 Standards-Version: 3.9.2
 Homepage: http://www.qtmoko.org
 Vcs-Git: git://github.com/radekp/qtmoko.git

--- a/debian/control-src
+++ b/debian/control-src
@@ -2,7 +2,7 @@ Source: qtmoko
 Section: comm
 Priority: optional
 Maintainer: Radek Polak <psonek2@seznam.cz>
-Build-Depends: debhelper (>= 7.0.50~), libqt4-dev, libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg8-dev, libv4l-dev, libqt4-sql-sqlite, libspeexdsp-dev, libsqlite3-dev
+Build-Depends: debhelper (>= 7.0.50~), libqt4-dev, libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg8-dev, libv4l-dev, libqt4-sql-sqlite, libspeexdsp-dev, libglib2.0-dev, libsqlite3-dev, quilt
 Standards-Version: 3.9.2
 Homepage: http://www.qtmoko.org
 Vcs-Git: git://github.com/radekp/qtmoko.git

--- a/debian/control-src
+++ b/debian/control-src
@@ -2,7 +2,7 @@ Source: qtmoko
 Section: comm
 Priority: optional
 Maintainer: Radek Polak <psonek2@seznam.cz>
-Build-Depends: debhelper (>= 7.0.50~), libqt4-dev, libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg8-dev, libv4l-dev, libqt4-sql-sqlite, libspeexdsp-dev
+Build-Depends: debhelper (>= 7.0.50~), libqt4-dev, libxext-dev, libasound2-dev, libdbus-1-dev, libssl-dev, libts-dev, libbluetooth-dev, libxtst-dev, libpng12-dev, libjpeg8-dev, libv4l-dev, libqt4-sql-sqlite, libspeexdsp-dev, libsqlite3-dev
 Standards-Version: 3.9.2
 Homepage: http://www.qtmoko.org
 Vcs-Git: git://github.com/radekp/qtmoko.git

--- a/debian/patches/disable-webkit-qt-tests.patch
+++ b/debian/patches/disable-webkit-qt-tests.patch
@@ -1,0 +1,13 @@
+Index: qtmoko/qtopiacore/qt/src/3rdparty/webkit/Source/WebKit.pro
+===================================================================
+--- qtmoko.orig/qtopiacore/qt/src/3rdparty/webkit/Source/WebKit.pro	2012-10-08 09:17:23.081423160 +0200
++++ qtmoko/qtopiacore/qt/src/3rdparty/webkit/Source/WebKit.pro	2012-10-09 15:36:14.074937440 +0200
+@@ -22,7 +22,7 @@
+     exists($$PWD/WebKit/qt/declarative): SUBDIRS += WebKit/qt/declarative
+ }
+ 
+-exists($$PWD/WebKit/qt/tests): SUBDIRS += WebKit/qt/tests
++#exists($$PWD/WebKit/qt/tests): SUBDIRS += WebKit/qt/tests
+ 
+ build-qtscript {
+     SUBDIRS += \

--- a/debian/patches/mkspec-library-prefix-suffix.patch
+++ b/debian/patches/mkspec-library-prefix-suffix.patch
@@ -1,0 +1,30 @@
+Index: qtmoko/devices/gta04/mkspecs/qws/linux-native-g++/qmake.conf
+===================================================================
+--- qtmoko.orig/devices/gta04/mkspecs/qws/linux-native-g++/qmake.conf	2012-10-10 07:48:37.700164936 +0200
++++ qtmoko/devices/gta04/mkspecs/qws/linux-native-g++/qmake.conf	2012-10-10 07:50:58.804854752 +0200
+@@ -8,6 +8,10 @@
+ QT                      += core gui network
+ QMAKE_INCREMENTAL_STYLE = sublib
+ 
++QMAKE_PREFIX_SHLIB      = lib
++QMAKE_PREFIX_STATICLIB  = lib
++QMAKE_EXTENSION_STATICLIB = a
++
+ QMAKE_CC		= gcc
+ QMAKE_LEX		= flex
+ QMAKE_LEXFLAGS		=
+Index: qtmoko/devices/neo/mkspecs/qws/linux-native-g++/qmake.conf
+===================================================================
+--- qtmoko.orig/devices/neo/mkspecs/qws/linux-native-g++/qmake.conf	2012-10-10 07:48:22.856092356 +0200
++++ qtmoko/devices/neo/mkspecs/qws/linux-native-g++/qmake.conf	2012-10-10 07:50:46.556794884 +0200
+@@ -8,6 +8,10 @@
+ QT                      += core gui network
+ QMAKE_INCREMENTAL_STYLE = sublib
+ 
++QMAKE_PREFIX_SHLIB      = lib
++QMAKE_PREFIX_STATICLIB  = lib
++QMAKE_EXTENSION_STATICLIB = a
++
+ QMAKE_CC		= gcc
+ QMAKE_LEX		= flex
+ QMAKE_LEXFLAGS		=

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,1 @@
-restart-when-modem-stops-working.patch
-mokofaen-as-default-theme.patch
-mkspec-library-prefix-suffix.patch
+series-main

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 restart-when-modem-stops-working.patch
 mokofaen-as-default-theme.patch
+mkspec-library-prefix-suffix.patch

--- a/debian/patches/series-main
+++ b/debian/patches/series-main
@@ -1,0 +1,3 @@
+restart-when-modem-stops-working.patch
+mokofaen-as-default-theme.patch
+mkspec-library-prefix-suffix.patch

--- a/debian/patches/series-qt48
+++ b/debian/patches/series-qt48
@@ -1,0 +1,1 @@
+disable-webkit-qt-tests.patch

--- a/debian/rules
+++ b/debian/rules
@@ -90,7 +90,7 @@ override_dh_auto_configure:
 	# Qt Extended configuration step
 	for device in $(DEVICES); do \
 		mkdir -p ../build-$$device; \
-		cd ../build-$$device && "$(CONFIGURE)" -device $$device -system-qt -xplatform $(TOOLCHAIN) -remove-module pkgmanagement -languages $(LANGUAGES) -l dbus-1 -I /usr/include/dbus-1.0/ -I /usr/lib/dbus-1.0/include; \
+		cd ../build-$$device && "$(CONFIGURE)" -device $$device -system-qt -xplatform $(TOOLCHAIN) -remove-module pkgmanagement -languages $(LANGUAGES) -extra-qt-embedded-config="-system-sqlite" -l dbus-1 -I /usr/include/dbus-1.0/ -I /usr/lib/dbus-1.0/include; \
 	done
 
 override_dh_auto_build:

--- a/debian/rules
+++ b/debian/rules
@@ -80,13 +80,6 @@ override_dh_auto_configure:
 			$(call QMAKE_CONF,$$device); \
 	done
 
-	# Fix wrong filename for libjscore.a
-	# http://qt-project.org/forums/viewthread/12732
-	for device in $(DEVICES); do \
-		mkdir -p $(CURDIR)/../build-$$device/qtopiacore/target/src/3rdparty/webkit/JavaScriptCore/release/; \
-		ln -s jscore. $(CURDIR)/../build-$$device/qtopiacore/target/src/3rdparty/webkit/JavaScriptCore/release/libjscore.a; \
-	done
-
 	# Qt Extended configuration step
 	for device in $(DEVICES); do \
 		mkdir -p ../build-$$device; \

--- a/debian/rules
+++ b/debian/rules
@@ -50,6 +50,7 @@ DEVICES := $(QTMOKO_DEVICES)
 QMAKE_CONF = devices/$1/mkspecs/qws/$(TOOLCHAIN)/qmake.conf
 
 QT_VERSION := $(shell grep '^\# *define *QT_VERSION_STR' "qtopiacore/qt/src/corelib/global/qglobal.h" | awk '{print $$3}')
+export QUILT_PATCHES=debian/patches
 
 %:
 	dh $@
@@ -63,6 +64,14 @@ debian/control:
 	done
 
 override_dh_auto_configure:
+	# Qt-4.8 specific patches
+	if [ "$$(echo "4.8\n$(QT_VERSION)" | sort -V | head -1)" = "4.8" ]; then \
+		if [ "$$(basename "$$(readlink -f debian/patches/series)")" = "series-main" ]; then \
+			rm -fr .pc; \
+		fi; \
+		ln -fs series-qt48 debian/patches/series; \
+		quilt push -a; \
+	fi
 	# Patch the qmake.conf file with proper toolchain configuration
 	for device in $(DEVICES); do \
 		sed -i.orig \
@@ -92,6 +101,14 @@ override_dh_auto_build:
 	done
 
 override_dh_auto_clean:
+	# If needed, revert QT_VERSION specific patches
+	if [ "$$(basename "$$(readlink -f debian/patches/series)")" != "series-main" ]; then \
+		if quilt app; then \
+			quilt pop -a; \
+		fi; \
+		ln -fs series-main debian/patches/series; \
+	fi
+
 	for device in $(DEVICES); do \
 		[ ! -f $(call QMAKE_CONF,$$device).orig ] || mv $(call QMAKE_CONF,$$device).orig $(call QMAKE_CONF,$$device); \
 		rm -fr ../build-$$device; \

--- a/debian/rules
+++ b/debian/rules
@@ -49,6 +49,8 @@ QTMOKO_DEVICES ?= gta04 neo
 DEVICES := $(QTMOKO_DEVICES)
 QMAKE_CONF = devices/$1/mkspecs/qws/$(TOOLCHAIN)/qmake.conf
 
+QT_VERSION := $(shell grep '^\# *define *QT_VERSION_STR' "qtopiacore/qt/src/corelib/global/qglobal.h" | awk '{print $$3}')
+
 %:
 	dh $@
 
@@ -123,7 +125,7 @@ override_dh_auto_install:
 
 	# Install missing dependency for qt_plugins/script/libqtscriptdbus.so
 	for device in $(DEVICES); do \
-		install -m"a+r,u+w" ../build-$$device/qtopiacore/target/lib/libQtScript.so.4.7.4 debian/tmp-$$device/opt/qtmoko/lib; \
+		install -m"a+r,u+w" ../build-$$device/qtopiacore/target/lib/libQtScript.so.$(QT_VERSION) debian/tmp-$$device/opt/qtmoko/lib; \
 	done
 	
 	# Install libQtDeclarative so that dh_shlibdeps does not complain


### PR DESCRIPTION
Hi Radek,

Here are 4 new commits resulting from my Qt 4.8.x support work.
- The patch mkspec-library-prefix-suffix.patch should  make its way int qtopiacore/qt if you approve it
- debian/rules is tweaked so that the Qt 4.8.x specific patch series applies only when the Qt version is > 4.8.

It still needs work regarding gst.

Thanks,

_g.
