### PR TITLE
Have libQtScript and libQtDeclarative installed by qbuild 

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -192,14 +192,6 @@ install_%:
 	# symlink to ttfont installed together with X
 	rm -rf debian/tmp-$(DEVICE)/opt/qtmoko/lib/fonts
 
-	# Install missing dependency for qt_plugins/script/libqtscriptdbus.so
-	install -m"a+r,u+w" ../build-$(DEVICE)/qtopiacore/target/lib/libQtScript.so.$(QT_VERSION) debian/tmp-$(DEVICE)/opt/qtmoko/lib
-	ln -s libQtScript.so.$(QT_VERSION) debian/tmp-$(DEVICE)/opt/qtmoko/lib/libQtScript.so.$(shell echo $(QT_VERSION) | sed 's/\.[0-9]*$$//')
-	ln -s libQtScript.so.$(QT_VERSION) debian/tmp-$(DEVICE)/opt/qtmoko/lib/libQtScript.so.$(shell echo $(QT_VERSION) | sed 's/\..*//')
-	
-	# Install libQtDeclarative so that dh_shlibdeps does not complain
-	install -m"a+r,u+w" ../build-$(DEVICE)/qtopiacore/target/lib/libQtDeclarative* debian/tmp-$(DEVICE)/opt/qtmoko/lib/
-
 
 override_dh_makeshlibs:
 	dh_makeshlibs -n

--- a/qbuild/extensions/qt.js
+++ b/qbuild/extensions/qt.js
@@ -274,6 +274,10 @@ function qt_get_libs(qtdir,sdkdir)
         ret.push(sdkdir+"/lib/libQtWebKit"+suffix);
     if (qconfig.property("QT_CONFIG").contains("dbus"))
         ret.push(sdkdir+"/lib/libQtDBus"+suffix);
+    if (qconfig.property("QT_CONFIG").contains("script"))
+        ret.push(sdkdir+"/lib/libQtScript"+suffix);
+    if (qconfig.property("QT_CONFIG").contains("declarative"))
+        ret.push(sdkdir+"/lib/libQtDeclarative"+suffix);
 
     // Qt doesn't tell us if this is on or not (use the Qt Extended switch instead)
     if (project.config("script"))


### PR DESCRIPTION
Hi Radek,

I've finally found a way to have libQtScript and libQtDeclarative installed by _qbuild image_. This avoid having to deal with them in debian/rules.

Thanks,

_g.
